### PR TITLE
Config release 6.22

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for XSConfig
 
+6.22    2016-09-10 21:06:56 rurban
+        -protect sv in END during global destruction, esp. with B::C
+        -fixes for no . in @INC (cperl or -Dfortify_inc)
+
 6.21    Sun, Jun 26, 2016  2:02:00 PM
         -more common keys for CPAN Testers
 

--- a/Config.pm
+++ b/Config.pm
@@ -10,7 +10,7 @@ use strict;
 use warnings;
 our (%Config, $VERSION);
 
-$VERSION = '6.21';
+$VERSION = '6.22';
 
 # Skip @Config::EXPORT because it only contains %Config, which we special
 # case below as it's not a function. @Config::EXPORT won't change in the

--- a/Config_mini.pl.PL
+++ b/Config_mini.pl.PL
@@ -3,14 +3,14 @@
 #usage: perl Config_mini.pl.PL [ignored]
 
 use strict ;
-my $VERSION = '6.00';
+my $VERSION = '6.22';
 use ExtUtils::Command;
 
 my $mini = searchdirs('Config_mini.pl', \@INC);
 if ($mini) {
     warn "found Config_mini.pl at $mini\n";
 
-    require 'xsc_test.pl'; #Config_mini.pl.PL not in cperl, no eval needed
+    require './xsc_test.pl'; #Config_mini.pl.PL not in cperl, no eval needed
     # test if Config_mini.pl is usuable in a seperate process since
     # Config_mini.pl might be so broken that the ExtUtils::Command::cp later on
     # might need something from %Config and %Config is broken after the broken

--- a/Config_xs.PL
+++ b/Config_xs.PL
@@ -19,7 +19,7 @@
 #    lib/Config_git.pl
 #
 
-$VERSION = '6.21';
+$VERSION = '6.22';
 my $in_core;
 
 BEGIN {
@@ -46,7 +46,7 @@ use Config ;
 if ($in_core) {
     require '../../regen/regen_lib.pl';
 } else {
-    require 'regen/regen_lib.pl';
+    require './regen/regen_lib.pl';
 }
 
 ###########################################################################

--- a/Config_xs.in
+++ b/Config_xs.in
@@ -1579,7 +1579,8 @@ PREINIT:
 PPCODE:
   SV * const sv = MY_CXT.defineSV;
   MY_CXT.defineSV = NULL;
-  SvREFCNT_dec_NN(sv);
+  if (sv) /* already NULL in global destruction */
+    SvREFCNT_dec_NN(sv);
   return; /* skip implicit PUTBACK, returning @_ to caller, more efficient*/
 
 #endif

--- a/Config_xs.out
+++ b/Config_xs.out
@@ -265,12 +265,12 @@ Config_lookup (register const char *str, register unsigned int len);
 
 struct Perl_Config;
 
-#define TOTAL_KEYWORDS 1288
+#define TOTAL_KEYWORDS 1292
 #define MIN_WORD_LENGTH 1
 #define MAX_WORD_LENGTH 30
 #define MIN_HASH_VALUE 3
-#define MAX_HASH_VALUE 10184
-/* maximum key range = 10182, duplicates = 0 */
+#define MAX_HASH_VALUE 9602
+/* maximum key range = 9600, duplicates = 0 */
 
 
 static unsigned int
@@ -278,32 +278,32 @@ Config_hash (register const char *str, register unsigned int len)
 {
   static const unsigned short asso_values[] =
     {
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,    27,    45,
-        127,    11,    19,    38,    12,    59,     8,    34,    16,     9,
-          2, 10185, 10185, 10185, 10185,     1,     3,     2,     3,     2,
-          6,     1,     6,     2,     2, 10185,     7,     1,     1,     2,
-         20,     3,     1,     2,     4,     2,     3,     3,     1,     2,
-      10185, 10185, 10185, 10185, 10185,     5,  1198,    29,   765,     7,
-          5,     2,   574,   826,  1323,     4,  1818,  2196,    75,   213,
-          2,   200,   109,  2084,    14,     1,     3,   427,  2048,  1982,
-       2376,  1087,   528,    17,     2,     2, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185,
-      10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185, 10185
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,    7,   30,
+        39,   25,   32,    3,    5,   26,   50,   53,   42,   38,
+        15, 9603, 9603, 9603, 9603,    1,    3,    1,    2,    1,
+         8,    3,    1,    1,    4, 9603,    3,    6,    1,    1,
+         2,    2,    2,    2,    3,    1,    1,    1,    2,    2,
+      9603, 9603, 9603, 9603, 9603,    2, 1797,   31, 1035,  135,
+         5,    2,  525,  833, 1373,    4, 1915, 2791,   58,  149,
+         2,   85,  184, 2053,   26,    1,    3,  421, 1974, 1266,
+      2356, 1057, 1940,    4,   18,    3, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603,
+      9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603, 9603
     };
   register int hval = len;
 
@@ -368,2584 +368,2592 @@ Config_hash (register const char *str, register unsigned int len)
 struct stringpool_t
   {
     char stringpool_str3[sizeof ("n")];
-    char stringpool_str8[sizeof ("c")];
-    char stringpool_str9[sizeof ("Id")];
+    char stringpool_str8[sizeof ("Id")];
+    char stringpool_str9[sizeof ("ARCH")];
     char stringpool_str10[sizeof ("tee")];
     char stringpool_str11[sizeof ("sed")];
     char stringpool_str13[sizeof ("test")];
-    char stringpool_str14[sizeof ("ARCH")];
-    char stringpool_str16[sizeof ("cc")];
-    char stringpool_str18[sizeof ("Mcc")];
-    char stringpool_str19[sizeof ("tr")];
-    char stringpool_str20[sizeof ("CONFIG")];
-    char stringpool_str25[sizeof ("src")];
-    char stringpool_str27[sizeof ("i_niin")];
-    char stringpool_str31[sizeof ("d_nice")];
-    char stringpool_str35[sizeof ("i_netdb")];
-    char stringpool_str36[sizeof ("_a")];
-    char stringpool_str39[sizeof ("d_rint")];
-    char stringpool_str40[sizeof ("sGMTIME_min")];
-    char stringpool_str41[sizeof ("Date")];
-    char stringpool_str42[sizeof ("cat")];
-    char stringpool_str43[sizeof ("date")];
-    char stringpool_str44[sizeof ("State")];
-    char stringpool_str45[sizeof ("ar")];
-    char stringpool_str48[sizeof ("d_nan")];
-    char stringpool_str49[sizeof ("tar")];
-    char stringpool_str50[sizeof ("SUBVERSION")];
-    char stringpool_str52[sizeof ("d_stat")];
-    char stringpool_str53[sizeof ("d_ctermid")];
-    char stringpool_str54[sizeof ("i_assert")];
-    char stringpool_str56[sizeof ("d_strerrm")];
-    char stringpool_str57[sizeof ("d_asinh")];
-    char stringpool_str61[sizeof ("d_strchr")];
-    char stringpool_str62[sizeof ("startsh")];
-    char stringpool_str64[sizeof ("Header")];
-    char stringpool_str65[sizeof ("PERL_REVISION")];
-    char stringpool_str66[sizeof ("dtrace")];
-    char stringpool_str67[sizeof ("d_access")];
-    char stringpool_str68[sizeof ("PERL_VERSION")];
-    char stringpool_str69[sizeof ("d_rename")];
-    char stringpool_str70[sizeof ("PERL_SUBVERSION")];
-    char stringpool_str72[sizeof ("PATCHLEVEL")];
-    char stringpool_str74[sizeof ("d_ctermid_r")];
-    char stringpool_str76[sizeof ("d_readdir")];
-    char stringpool_str78[sizeof ("ls")];
-    char stringpool_str79[sizeof ("ln")];
-    char stringpool_str81[sizeof ("lns")];
-    char stringpool_str82[sizeof ("ld")];
-    char stringpool_str83[sizeof ("less")];
-    char stringpool_str84[sizeof ("d_atanh")];
-    char stringpool_str85[sizeof ("sPRIi64")];
-    char stringpool_str86[sizeof ("sPRId64")];
-    char stringpool_str87[sizeof ("line")];
-    char stringpool_str88[sizeof ("lint")];
-    char stringpool_str96[sizeof ("d_PRIXU64")];
-    char stringpool_str97[sizeof ("d_readdir_r")];
-    char stringpool_str98[sizeof ("trnl")];
-    char stringpool_str99[sizeof ("i_dld")];
-    char stringpool_str103[sizeof ("sitelib")];
-    char stringpool_str104[sizeof ("d_isless")];
-    char stringpool_str106[sizeof ("d_select")];
-    char stringpool_str107[sizeof ("dlsrc")];
-    char stringpool_str108[sizeof ("PERL_PATCHLEVEL")];
-    char stringpool_str113[sizeof ("sPRIXU64")];
-    char stringpool_str115[sizeof ("tail")];
-    char stringpool_str118[sizeof ("cp")];
-    char stringpool_str123[sizeof ("d_PRIi64")];
-    char stringpool_str124[sizeof ("d_PRId64")];
-    char stringpool_str125[sizeof ("pr")];
-    char stringpool_str132[sizeof ("d_class")];
-    char stringpool_str139[sizeof ("d_scalbn")];
-    char stringpool_str141[sizeof ("d_srand48_r")];
-    char stringpool_str145[sizeof ("d_drand48_r")];
-    char stringpool_str148[sizeof ("d_dladdr")];
-    char stringpool_str153[sizeof ("d_strtod")];
-    char stringpool_str154[sizeof ("scriptdir")];
-    char stringpool_str157[sizeof ("sLOCALTIME_min")];
-    char stringpool_str165[sizeof ("incpath")];
-    char stringpool_str166[sizeof ("d_alarm")];
-    char stringpool_str174[sizeof ("d_sanemcmp")];
-    char stringpool_str178[sizeof ("d_strerror")];
-    char stringpool_str181[sizeof ("d_telldir")];
-    char stringpool_str186[sizeof ("lp")];
-    char stringpool_str194[sizeof ("sleep")];
-    char stringpool_str201[sizeof ("lpr")];
-    char stringpool_str203[sizeof ("so")];
-    char stringpool_str204[sizeof ("perl")];
-    char stringpool_str205[sizeof ("to")];
-    char stringpool_str207[sizeof ("_o")];
-    char stringpool_str214[sizeof ("d_statblks")];
-    char stringpool_str216[sizeof ("drand01")];
-    char stringpool_str217[sizeof ("nm")];
-    char stringpool_str222[sizeof ("sort")];
-    char stringpool_str223[sizeof ("d_strtol")];
-    char stringpool_str226[sizeof ("d_strtold")];
-    char stringpool_str228[sizeof ("cpp")];
-    char stringpool_str229[sizeof ("rm")];
-    char stringpool_str230[sizeof ("sitelib_stem")];
-    char stringpool_str231[sizeof ("d_sem")];
-    char stringpool_str233[sizeof ("i_stdint")];
-    char stringpool_str237[sizeof ("i_time")];
-    char stringpool_str238[sizeof ("d_time")];
-    char stringpool_str240[sizeof ("d_pipe")];
-    char stringpool_str242[sizeof ("d_times")];
-    char stringpool_str243[sizeof ("perl5")];
-    char stringpool_str245[sizeof ("i_dirent")];
-    char stringpool_str250[sizeof ("mad")];
-    char stringpool_str253[sizeof ("d_isnan")];
-    char stringpool_str254[sizeof ("d_rmdir")];
-    char stringpool_str257[sizeof ("emacs")];
-    char stringpool_str258[sizeof ("d_acosh")];
-    char stringpool_str263[sizeof ("d_setprior")];
-    char stringpool_str266[sizeof ("ccname")];
-    char stringpool_str268[sizeof ("d_aintl")];
-    char stringpool_str269[sizeof ("stdio_base")];
-    char stringpool_str272[sizeof ("man3dir")];
-    char stringpool_str281[sizeof ("sPRIo64")];
-    char stringpool_str290[sizeof ("d_srandom_r")];
-    char stringpool_str295[sizeof ("perllibs")];
-    char stringpool_str306[sizeof ("man1dir")];
-    char stringpool_str316[sizeof ("timeincl")];
-    char stringpool_str317[sizeof ("d_dlerror")];
-    char stringpool_str319[sizeof ("d_PRIo64")];
-    char stringpool_str324[sizeof ("cpio")];
-    char stringpool_str325[sizeof ("mail")];
-    char stringpool_str327[sizeof ("smail")];
-    char stringpool_str329[sizeof ("d_isnanl")];
-    char stringpool_str337[sizeof ("sPRIGUldbl")];
-    char stringpool_str338[sizeof ("sPRIEUldbl")];
-    char stringpool_str340[sizeof ("rmail")];
-    char stringpool_str341[sizeof ("i_prot")];
-    char stringpool_str342[sizeof ("sPRIFUldbl")];
-    char stringpool_str345[sizeof ("d_PRIeldbl")];
-    char stringpool_str349[sizeof ("d_open3")];
-    char stringpool_str353[sizeof ("d_scalbnl")];
-    char stringpool_str363[sizeof ("d_prctl")];
-    char stringpool_str365[sizeof ("installscript")];
-    char stringpool_str367[sizeof ("d_ip_mreq")];
-    char stringpool_str389[sizeof ("d_llrint")];
-    char stringpool_str417[sizeof ("d_ip_mreq_source")];
-    char stringpool_str433[sizeof ("more")];
-    char stringpool_str437[sizeof ("d_strtoll")];
-    char stringpool_str440[sizeof ("i_mntent")];
-    char stringpool_str441[sizeof ("d_strcoll")];
-    char stringpool_str443[sizeof ("i_neterrno")];
-    char stringpool_str446[sizeof ("run")];
-    char stringpool_str449[sizeof ("perladmin")];
-    char stringpool_str452[sizeof ("d_inetntop")];
-    char stringpool_str453[sizeof ("osname")];
-    char stringpool_str454[sizeof ("contains")];
-    char stringpool_str460[sizeof ("d_eunice")];
-    char stringpool_str461[sizeof ("usrinc")];
-    char stringpool_str463[sizeof ("d_cuserid")];
-    char stringpool_str466[sizeof ("d_drand48proto")];
-    char stringpool_str468[sizeof ("d_trunc")];
-    char stringpool_str471[sizeof ("d_memchr")];
-    char stringpool_str474[sizeof ("i_poll")];
-    char stringpool_str475[sizeof ("d_poll")];
-    char stringpool_str480[sizeof ("d_setitimer")];
-    char stringpool_str491[sizeof ("d_oldsock")];
-    char stringpool_str492[sizeof ("ppmarch")];
-    char stringpool_str494[sizeof ("siteman3dir")];
-    char stringpool_str504[sizeof ("d_lseekproto")];
-    char stringpool_str508[sizeof ("sPRIu64")];
-    char stringpool_str510[sizeof ("d_int64_t")];
-    char stringpool_str515[sizeof ("usedl")];
-    char stringpool_str523[sizeof ("d_telldirproto")];
-    char stringpool_str525[sizeof ("i_malloc")];
-    char stringpool_str528[sizeof ("siteman1dir")];
-    char stringpool_str537[sizeof ("d_atoll")];
-    char stringpool_str538[sizeof ("nm_opt")];
-    char stringpool_str539[sizeof ("d_lrint")];
-    char stringpool_str543[sizeof ("i_locale")];
-    char stringpool_str544[sizeof ("d_truncl")];
-    char stringpool_str546[sizeof ("d_PRIu64")];
-    char stringpool_str552[sizeof ("d_lstat")];
-    char stringpool_str553[sizeof ("i8size")];
-    char stringpool_str557[sizeof ("compress")];
-    char stringpool_str560[sizeof ("optimize")];
-    char stringpool_str564[sizeof ("d_memcmp")];
-    char stringpool_str567[sizeof ("sizesize")];
-    char stringpool_str571[sizeof ("zcat")];
-    char stringpool_str573[sizeof ("d_strlcat")];
-    char stringpool_str577[sizeof ("use5005threads")];
-    char stringpool_str580[sizeof ("d_mmap")];
-    char stringpool_str584[sizeof ("d_tzname")];
-    char stringpool_str589[sizeof ("find")];
-    char stringpool_str590[sizeof ("d_strtouq")];
-    char stringpool_str603[sizeof ("d_llrintl")];
-    char stringpool_str605[sizeof ("d_erf")];
-    char stringpool_str607[sizeof ("afs")];
-    char stringpool_str610[sizeof ("passcat")];
-    char stringpool_str612[sizeof ("d_strerror_r")];
-    char stringpool_str613[sizeof ("d_erfc")];
-    char stringpool_str615[sizeof ("d_lrintl")];
-    char stringpool_str616[sizeof ("d_dirfd")];
-    char stringpool_str630[sizeof ("mallocsrc")];
-    char stringpool_str632[sizeof ("usecperl")];
-    char stringpool_str637[sizeof ("comm")];
-    char stringpool_str642[sizeof ("d_eaccess")];
-    char stringpool_str644[sizeof ("zip")];
-    char stringpool_str650[sizeof ("usenm")];
-    char stringpool_str654[sizeof ("d_const")];
-    char stringpool_str658[sizeof ("Source")];
-    char stringpool_str661[sizeof ("stdio_cnt")];
-    char stringpool_str662[sizeof ("d_round")];
-    char stringpool_str663[sizeof ("runnm")];
-    char stringpool_str672[sizeof ("i_netinettcp")];
-    char stringpool_str674[sizeof ("cpprun")];
-    char stringpool_str676[sizeof ("d_unordered")];
-    char stringpool_str678[sizeof ("uname")];
-    char stringpool_str684[sizeof ("d_dup2")];
-    char stringpool_str696[sizeof ("i_fp")];
-    char stringpool_str722[sizeof ("usesocks")];
-    char stringpool_str741[sizeof ("i_limits")];
-    char stringpool_str743[sizeof ("d_semctl")];
-    char stringpool_str754[sizeof ("d_strlcpy")];
-    char stringpool_str762[sizeof ("d_umask")];
-    char stringpool_str764[sizeof ("cpplast")];
-    char stringpool_str772[sizeof ("multiarch")];
-    char stringpool_str774[sizeof ("bin")];
-    char stringpool_str778[sizeof ("dlltool")];
-    char stringpool_str783[sizeof ("i_db")];
-    char stringpool_str786[sizeof ("d_bsd")];
-    char stringpool_str789[sizeof ("d_strtoul")];
-    char stringpool_str792[sizeof ("d_ualarm")];
-    char stringpool_str793[sizeof ("bin_ELF")];
-    char stringpool_str794[sizeof ("i_sfio")];
-    char stringpool_str795[sizeof ("d_sfio")];
-    char stringpool_str796[sizeof ("ebcdic")];
-    char stringpool_str805[sizeof ("d_cbrt")];
-    char stringpool_str809[sizeof ("d_fmin")];
-    char stringpool_str812[sizeof ("d_fdim")];
-    char stringpool_str815[sizeof ("i_fcntl")];
-    char stringpool_str816[sizeof ("d_fcntl")];
-    char stringpool_str825[sizeof ("readdir_r_proto")];
-    char stringpool_str826[sizeof ("d_ctime_r")];
-    char stringpool_str831[sizeof ("d_fma")];
-    char stringpool_str840[sizeof ("d_faststdio")];
-    char stringpool_str844[sizeof ("i_mallocmalloc")];
-    char stringpool_str846[sizeof ("tbl")];
-    char stringpool_str847[sizeof ("PERL_CONFIG_SH")];
-    char stringpool_str849[sizeof ("libs")];
-    char stringpool_str854[sizeof ("d_isinf")];
-    char stringpool_str855[sizeof ("libc")];
-    char stringpool_str860[sizeof ("strings")];
-    char stringpool_str864[sizeof ("libsdirs")];
-    char stringpool_str865[sizeof ("d_strtoull")];
-    char stringpool_str868[sizeof ("sig_size")];
-    char stringpool_str869[sizeof ("srand48_r_proto")];
-    char stringpool_str870[sizeof ("d_ctime64")];
-    char stringpool_str872[sizeof ("d_fseeko")];
-    char stringpool_str873[sizeof ("drand48_r_proto")];
-    char stringpool_str876[sizeof ("d_readdir64_r")];
-    char stringpool_str877[sizeof ("i_dlfcn")];
-    char stringpool_str879[sizeof ("sig_name")];
-    char stringpool_str880[sizeof ("initialinstalllocation")];
-    char stringpool_str882[sizeof ("i_stdarg")];
-    char stringpool_str883[sizeof ("i_unistd")];
-    char stringpool_str890[sizeof ("useperlio")];
-    char stringpool_str893[sizeof ("targetdir")];
-    char stringpool_str895[sizeof ("ranlib")];
-    char stringpool_str898[sizeof ("eagain")];
-    char stringpool_str899[sizeof ("d_SCNfldbl")];
-    char stringpool_str901[sizeof ("d_getaddrinfo")];
-    char stringpool_str903[sizeof ("i_ustat")];
-    char stringpool_str904[sizeof ("d_ustat")];
-    char stringpool_str910[sizeof ("d_inetaton")];
-    char stringpool_str916[sizeof ("fpossize")];
-    char stringpool_str917[sizeof ("d_PRIfldbl")];
-    char stringpool_str929[sizeof ("d_truncate")];
-    char stringpool_str930[sizeof ("d_isinfl")];
-    char stringpool_str937[sizeof ("pg")];
-    char stringpool_str939[sizeof ("d_lround")];
-    char stringpool_str948[sizeof ("d_flock")];
-    char stringpool_str954[sizeof ("d_eofnblk")];
-    char stringpool_str955[sizeof ("grep")];
-    char stringpool_str958[sizeof ("egrep")];
-    char stringpool_str960[sizeof ("i_fp_class")];
-    char stringpool_str961[sizeof ("d_fp_class")];
-    char stringpool_str962[sizeof ("i_ieeefp")];
-    char stringpool_str963[sizeof ("i_grp")];
-    char stringpool_str964[sizeof ("d_setgrps")];
-    char stringpool_str965[sizeof ("d_PRIGUldbl")];
-    char stringpool_str966[sizeof ("d_PRIEUldbl")];
-    char stringpool_str969[sizeof ("startperl")];
-    char stringpool_str970[sizeof ("d_PRIFUldbl")];
-    char stringpool_str972[sizeof ("d_fp_classify")];
-    char stringpool_str976[sizeof ("u8size")];
-    char stringpool_str977[sizeof ("bison")];
-    char stringpool_str978[sizeof ("d_regcmp")];
-    char stringpool_str983[sizeof ("d_dlopen")];
-    char stringpool_str985[sizeof ("pager")];
-    char stringpool_str986[sizeof ("sitebin")];
-    char stringpool_str993[sizeof ("d_mprotect")];
-    char stringpool_str997[sizeof ("i_dbm")];
-    char stringpool_str1000[sizeof ("i_ndbm")];
-    char stringpool_str1001[sizeof ("d_ndbm")];
-    char stringpool_str1005[sizeof ("from")];
-    char stringpool_str1010[sizeof ("ctermid_r_proto")];
-    char stringpool_str1018[sizeof ("srandom_r_proto")];
-    char stringpool_str1024[sizeof ("d_memset")];
-    char stringpool_str1029[sizeof ("d_setsent")];
-    char stringpool_str1030[sizeof ("d_setnent")];
-    char stringpool_str1031[sizeof ("d_finite")];
-    char stringpool_str1032[sizeof ("d_endsent")];
-    char stringpool_str1033[sizeof ("d_endnent")];
-    char stringpool_str1034[sizeof ("d_futimes")];
-    char stringpool_str1036[sizeof ("Log")];
-    char stringpool_str1037[sizeof ("d_fp_classl")];
-    char stringpool_str1044[sizeof ("d_fds_bits")];
-    char stringpool_str1047[sizeof ("d_strftime")];
-    char stringpool_str1055[sizeof ("d_msg")];
-    char stringpool_str1058[sizeof ("d_setgrent")];
-    char stringpool_str1060[sizeof ("d_setlocale")];
-    char stringpool_str1061[sizeof ("d_endgrent")];
-    char stringpool_str1065[sizeof ("i_string")];
-    char stringpool_str1076[sizeof ("plibpth")];
-    char stringpool_str1080[sizeof ("nm_so_opt")];
-    char stringpool_str1084[sizeof ("d_cmsghdr_s")];
-    char stringpool_str1085[sizeof ("d_ftello")];
-    char stringpool_str1088[sizeof ("d_getprior")];
-    char stringpool_str1090[sizeof ("sPRIeldbl")];
-    char stringpool_str1091[sizeof ("mistrustnm")];
-    char stringpool_str1097[sizeof ("targethost")];
-    char stringpool_str1101[sizeof ("installprefix")];
-    char stringpool_str1106[sizeof ("uuname")];
-    char stringpool_str1110[sizeof ("d_bcmp")];
-    char stringpool_str1116[sizeof ("i_sysndir")];
-    char stringpool_str1117[sizeof ("d_index")];
-    char stringpool_str1120[sizeof ("d_tgamma")];
-    char stringpool_str1123[sizeof ("intsize")];
-    char stringpool_str1125[sizeof ("usesfio")];
+    char stringpool_str21[sizeof ("CONFIG")];
+    char stringpool_str24[sizeof ("i_niin")];
+    char stringpool_str25[sizeof ("sPRIi64")];
+    char stringpool_str26[sizeof ("sPRId64")];
+    char stringpool_str27[sizeof ("SUBVERSION")];
+    char stringpool_str31[sizeof ("tr")];
+    char stringpool_str32[sizeof ("d_PRIXU64")];
+    char stringpool_str35[sizeof ("_a")];
+    char stringpool_str38[sizeof ("PERL_SUBVERSION")];
+    char stringpool_str40[sizeof ("PERL_VERSION")];
+    char stringpool_str41[sizeof ("PATCHLEVEL")];
+    char stringpool_str42[sizeof ("Date")];
+    char stringpool_str43[sizeof ("PERL_REVISION")];
+    char stringpool_str44[sizeof ("PERL_PATCHLEVEL")];
+    char stringpool_str45[sizeof ("date")];
+    char stringpool_str46[sizeof ("State")];
+    char stringpool_str47[sizeof ("d_nan")];
+    char stringpool_str48[sizeof ("d_rint")];
+    char stringpool_str49[sizeof ("sGMTIME_min")];
+    char stringpool_str51[sizeof ("d_stat")];
+    char stringpool_str53[sizeof ("i_assert")];
+    char stringpool_str56[sizeof ("d_asinh")];
+    char stringpool_str59[sizeof ("ar")];
+    char stringpool_str61[sizeof ("ls")];
+    char stringpool_str62[sizeof ("ln")];
+    char stringpool_str63[sizeof ("tar")];
+    char stringpool_str64[sizeof ("lns")];
+    char stringpool_str65[sizeof ("ld")];
+    char stringpool_str66[sizeof ("less")];
+    char stringpool_str70[sizeof ("line")];
+    char stringpool_str71[sizeof ("lint")];
+    char stringpool_str73[sizeof ("Header")];
+    char stringpool_str75[sizeof ("sPRIXU64")];
+    char stringpool_str76[sizeof ("startsh")];
+    char stringpool_str77[sizeof ("d_strerrm")];
+    char stringpool_str79[sizeof ("i_dld")];
+    char stringpool_str80[sizeof ("d_rename")];
+    char stringpool_str82[sizeof ("d_PRIi64")];
+    char stringpool_str83[sizeof ("d_PRId64")];
+    char stringpool_str84[sizeof ("d_isless")];
+    char stringpool_str85[sizeof ("d_atanh")];
+    char stringpool_str86[sizeof ("d_select")];
+    char stringpool_str87[sizeof ("d_readdir")];
+    char stringpool_str88[sizeof ("so")];
+    char stringpool_str89[sizeof ("_o")];
+    char stringpool_str90[sizeof ("to")];
+    char stringpool_str93[sizeof ("trnl")];
+    char stringpool_str100[sizeof ("tail")];
+    char stringpool_str106[sizeof ("sPRIo64")];
+    char stringpool_str115[sizeof ("i_stdint")];
+    char stringpool_str117[sizeof ("d_readdir_r")];
+    char stringpool_str119[sizeof ("sort")];
+    char stringpool_str122[sizeof ("drand01")];
+    char stringpool_str136[sizeof ("c")];
+    char stringpool_str137[sizeof ("d_isnan")];
+    char stringpool_str139[sizeof ("i_dirent")];
+    char stringpool_str142[sizeof ("d_dladdr")];
+    char stringpool_str144[sizeof ("d_telldir")];
+    char stringpool_str153[sizeof ("nm")];
+    char stringpool_str156[sizeof ("d_nice")];
+    char stringpool_str160[sizeof ("i_netdb")];
+    char stringpool_str162[sizeof ("d_alarm")];
+    char stringpool_str163[sizeof ("d_PRIo64")];
+    char stringpool_str164[sizeof ("d_sem")];
+    char stringpool_str165[sizeof ("src")];
+    char stringpool_str170[sizeof ("i_time")];
+    char stringpool_str171[sizeof ("d_time")];
+    char stringpool_str172[sizeof ("cat")];
+    char stringpool_str175[sizeof ("d_times")];
+    char stringpool_str177[sizeof ("rm")];
+    char stringpool_str188[sizeof ("mad")];
+    char stringpool_str190[sizeof ("d_ctermid")];
+    char stringpool_str193[sizeof ("d_srand48_r")];
+    char stringpool_str194[sizeof ("d_dlerror")];
+    char stringpool_str195[sizeof ("d_srandom_r")];
+    char stringpool_str196[sizeof ("d_isnanl")];
+    char stringpool_str197[sizeof ("d_drand48_r")];
+    char stringpool_str199[sizeof ("d_rmdir")];
+    char stringpool_str203[sizeof ("d_aintl")];
+    char stringpool_str208[sizeof ("dtrace")];
+    char stringpool_str210[sizeof ("d_strchr")];
+    char stringpool_str212[sizeof ("pr")];
+    char stringpool_str214[sizeof ("sitelib")];
+    char stringpool_str216[sizeof ("sLOCALTIME_min")];
+    char stringpool_str220[sizeof ("d_ctermid_r")];
+    char stringpool_str222[sizeof ("i_neterrno")];
+    char stringpool_str224[sizeof ("man3dir")];
+    char stringpool_str229[sizeof ("man1dir")];
+    char stringpool_str230[sizeof ("dlsrc")];
+    char stringpool_str235[sizeof ("timeincl")];
+    char stringpool_str237[sizeof ("d_strtod")];
+    char stringpool_str242[sizeof ("d_class")];
+    char stringpool_str244[sizeof ("lp")];
+    char stringpool_str246[sizeof ("mail")];
+    char stringpool_str248[sizeof ("smail")];
+    char stringpool_str249[sizeof ("d_llrint")];
+    char stringpool_str252[sizeof ("sleep")];
+    char stringpool_str258[sizeof ("i_mntent")];
+    char stringpool_str266[sizeof ("more")];
+    char stringpool_str270[sizeof ("d_acosh")];
+    char stringpool_str271[sizeof ("lpr")];
+    char stringpool_str272[sizeof ("cc")];
+    char stringpool_str273[sizeof ("rmail")];
+    char stringpool_str274[sizeof ("perl")];
+    char stringpool_str276[sizeof ("osname")];
+    char stringpool_str278[sizeof ("perl5")];
+    char stringpool_str279[sizeof ("Mcc")];
+    char stringpool_str281[sizeof ("stdio_base")];
+    char stringpool_str286[sizeof ("d_strerror")];
+    char stringpool_str290[sizeof ("d_strtol")];
+    char stringpool_str293[sizeof ("d_strtold")];
+    char stringpool_str298[sizeof ("installscript")];
+    char stringpool_str307[sizeof ("d_statblks")];
+    char stringpool_str310[sizeof ("i_prot")];
+    char stringpool_str319[sizeof ("d_open3")];
+    char stringpool_str321[sizeof ("cp")];
+    char stringpool_str322[sizeof ("d_access")];
+    char stringpool_str323[sizeof ("emacs")];
+    char stringpool_str340[sizeof ("d_atoll")];
+    char stringpool_str343[sizeof ("siteman3dir")];
+    char stringpool_str348[sizeof ("siteman1dir")];
+    char stringpool_str354[sizeof ("contains")];
+    char stringpool_str365[sizeof ("sPRIEUldbl")];
+    char stringpool_str367[sizeof ("sPRIGUldbl")];
+    char stringpool_str369[sizeof ("scriptdir")];
+    char stringpool_str370[sizeof ("incpath")];
+    char stringpool_str371[sizeof ("d_PRIeldbl")];
+    char stringpool_str372[sizeof ("sPRIFUldbl")];
+    char stringpool_str376[sizeof ("d_sanemcmp")];
+    char stringpool_str377[sizeof ("d_scalbn")];
+    char stringpool_str384[sizeof ("d_ip_mreq")];
+    char stringpool_str387[sizeof ("d_pipe")];
+    char stringpool_str397[sizeof ("i_poll")];
+    char stringpool_str398[sizeof ("d_poll")];
+    char stringpool_str399[sizeof ("d_llrintl")];
+    char stringpool_str406[sizeof ("perladmin")];
+    char stringpool_str412[sizeof ("cpio")];
+    char stringpool_str413[sizeof ("sitelib_stem")];
+    char stringpool_str422[sizeof ("d_setprior")];
+    char stringpool_str431[sizeof ("nm_opt")];
+    char stringpool_str439[sizeof ("d_lseekproto")];
+    char stringpool_str440[sizeof ("d_strtoll")];
+    char stringpool_str442[sizeof ("sPRIu64")];
+    char stringpool_str443[sizeof ("optimize")];
+    char stringpool_str450[sizeof ("dlltool")];
+    char stringpool_str451[sizeof ("d_eunice")];
+    char stringpool_str452[sizeof ("run")];
+    char stringpool_str456[sizeof ("d_int64_t")];
+    char stringpool_str460[sizeof ("ccname")];
+    char stringpool_str470[sizeof ("d_telldirproto")];
+    char stringpool_str471[sizeof ("d_trunc")];
+    char stringpool_str474[sizeof ("i_locale")];
+    char stringpool_str476[sizeof ("perllibs")];
+    char stringpool_str480[sizeof ("d_memchr")];
+    char stringpool_str483[sizeof ("d_setitimer")];
+    char stringpool_str484[sizeof ("d_inetntop")];
+    char stringpool_str492[sizeof ("usedl")];
+    char stringpool_str493[sizeof ("d_drand48proto")];
+    char stringpool_str499[sizeof ("d_PRIu64")];
+    char stringpool_str501[sizeof ("use5005threads")];
+    char stringpool_str506[sizeof ("cpp")];
+    char stringpool_str511[sizeof ("d_prctl")];
+    char stringpool_str522[sizeof ("comm")];
+    char stringpool_str525[sizeof ("d_lrint")];
+    char stringpool_str526[sizeof ("d_mmap")];
+    char stringpool_str527[sizeof ("d_scalbnl")];
+    char stringpool_str528[sizeof ("d_lstat")];
+    char stringpool_str530[sizeof ("d_truncl")];
+    char stringpool_str537[sizeof ("stdio_cnt")];
+    char stringpool_str540[sizeof ("find")];
+    char stringpool_str542[sizeof ("d_oldsock")];
+    char stringpool_str544[sizeof ("i_netinet_ip")];
+    char stringpool_str545[sizeof ("i_netinet_ip6")];
+    char stringpool_str550[sizeof ("d_round")];
+    char stringpool_str559[sizeof ("mallocsrc")];
+    char stringpool_str560[sizeof ("afs")];
+    char stringpool_str561[sizeof ("d_strlcat")];
+    char stringpool_str564[sizeof ("d_unordered")];
+    char stringpool_str565[sizeof ("d_erf")];
+    char stringpool_str572[sizeof ("d_strcoll")];
+    char stringpool_str576[sizeof ("d_dirfd")];
+    char stringpool_str580[sizeof ("usenm")];
+    char stringpool_str582[sizeof ("d_cuserid")];
+    char stringpool_str583[sizeof ("d_ip_mreq_source")];
+    char stringpool_str584[sizeof ("d_lrintl")];
+    char stringpool_str593[sizeof ("compress")];
+    char stringpool_str595[sizeof ("usrinc")];
+    char stringpool_str605[sizeof ("runnm")];
+    char stringpool_str609[sizeof ("i_netinet6_in6")];
+    char stringpool_str610[sizeof ("uname")];
+    char stringpool_str627[sizeof ("i_sfio")];
+    char stringpool_str628[sizeof ("d_sfio")];
+    char stringpool_str629[sizeof ("i_malloc")];
+    char stringpool_str636[sizeof ("d_memcmp")];
+    char stringpool_str651[sizeof ("i_limits")];
+    char stringpool_str658[sizeof ("d_const")];
+    char stringpool_str662[sizeof ("d_dup2")];
+    char stringpool_str674[sizeof ("d_umask")];
+    char stringpool_str675[sizeof ("d_faststdio")];
+    char stringpool_str676[sizeof ("i_netinettcp")];
+    char stringpool_str677[sizeof ("Source")];
+    char stringpool_str680[sizeof ("d_strtouq")];
+    char stringpool_str684[sizeof ("initialinstalllocation")];
+    char stringpool_str688[sizeof ("d_fseeko")];
+    char stringpool_str693[sizeof ("d_fmin")];
+    char stringpool_str695[sizeof ("d_lround")];
+    char stringpool_str696[sizeof ("d_fdim")];
+    char stringpool_str701[sizeof ("d_erfc")];
+    char stringpool_str706[sizeof ("d_ualarm")];
+    char stringpool_str711[sizeof ("d_strerror_r")];
+    char stringpool_str712[sizeof ("usesocks")];
+    char stringpool_str717[sizeof ("d_fma")];
+    char stringpool_str719[sizeof ("i_fp")];
+    char stringpool_str720[sizeof ("ppmarch")];
+    char stringpool_str781[sizeof ("d_semctl")];
+    char stringpool_str787[sizeof ("readdir_r_proto")];
+    char stringpool_str789[sizeof ("from")];
+    char stringpool_str803[sizeof ("d_strtoul")];
+    char stringpool_str811[sizeof ("passcat")];
+    char stringpool_str812[sizeof ("usecperl")];
+    char stringpool_str814[sizeof ("fpossize")];
+    char stringpool_str815[sizeof ("multiarch")];
+    char stringpool_str821[sizeof ("i_dlfcn")];
+    char stringpool_str827[sizeof ("i_fcntl")];
+    char stringpool_str828[sizeof ("d_fcntl")];
+    char stringpool_str835[sizeof ("d_ctime_r")];
+    char stringpool_str837[sizeof ("d_ftello")];
+    char stringpool_str840[sizeof ("d_ctime64")];
+    char stringpool_str844[sizeof ("d_memset")];
+    char stringpool_str845[sizeof ("d_lroundl")];
+    char stringpool_str848[sizeof ("d_eaccess")];
+    char stringpool_str854[sizeof ("mistrustnm")];
+    char stringpool_str858[sizeof ("d_isinf")];
+    char stringpool_str859[sizeof ("sig_size")];
+    char stringpool_str862[sizeof ("d_strtoull")];
+    char stringpool_str863[sizeof ("srand48_r_proto")];
+    char stringpool_str865[sizeof ("srandom_r_proto")];
+    char stringpool_str867[sizeof ("drand48_r_proto")];
+    char stringpool_str868[sizeof ("i_unistd")];
+    char stringpool_str874[sizeof ("d_dlopen")];
+    char stringpool_str875[sizeof ("d_flock")];
+    char stringpool_str879[sizeof ("strings")];
+    char stringpool_str881[sizeof ("d_eofnblk")];
+    char stringpool_str885[sizeof ("sig_name")];
+    char stringpool_str888[sizeof ("i_stdarg")];
+    char stringpool_str890[sizeof ("i_ustat")];
+    char stringpool_str891[sizeof ("d_ustat")];
+    char stringpool_str892[sizeof ("d_mprotect")];
+    char stringpool_str893[sizeof ("d_SCNfldbl")];
+    char stringpool_str894[sizeof ("d_PRIfldbl")];
+    char stringpool_str907[sizeof ("d_getaddrinfo")];
+    char stringpool_str909[sizeof ("eagain")];
+    char stringpool_str914[sizeof ("targetdir")];
+    char stringpool_str917[sizeof ("d_isinfl")];
+    char stringpool_str924[sizeof ("Log")];
+    char stringpool_str927[sizeof ("d_modfl")];
+    char stringpool_str928[sizeof ("d_truncate")];
+    char stringpool_str946[sizeof ("i_mallocmalloc")];
+    char stringpool_str947[sizeof ("d_setgrent")];
+    char stringpool_str950[sizeof ("d_endgrent")];
+    char stringpool_str957[sizeof ("startperl")];
+    char stringpool_str958[sizeof ("cpprun")];
+    char stringpool_str966[sizeof ("i_string")];
+    char stringpool_str971[sizeof ("d_setsent")];
+    char stringpool_str972[sizeof ("d_setnent")];
+    char stringpool_str973[sizeof ("d_finite")];
+    char stringpool_str974[sizeof ("d_endsent")];
+    char stringpool_str975[sizeof ("d_endnent")];
+    char stringpool_str976[sizeof ("d_futimes")];
+    char stringpool_str982[sizeof ("useperlio")];
+    char stringpool_str989[sizeof ("usecrosscompile")];
+    char stringpool_str995[sizeof ("d_msg")];
+    char stringpool_str997[sizeof ("longsize")];
+    char stringpool_str1001[sizeof ("d_strftime")];
+    char stringpool_str1003[sizeof ("targethost")];
+    char stringpool_str1019[sizeof ("pg")];
+    char stringpool_str1021[sizeof ("cpplast")];
+    char stringpool_str1024[sizeof ("d_atolf")];
+    char stringpool_str1028[sizeof ("d_log2")];
+    char stringpool_str1031[sizeof ("installprefix")];
+    char stringpool_str1032[sizeof ("uuname")];
+    char stringpool_str1034[sizeof ("ctermid_r_proto")];
+    char stringpool_str1039[sizeof ("nm_so_opt")];
+    char stringpool_str1041[sizeof ("i_ieeefp")];
+    char stringpool_str1043[sizeof ("d_setgrps")];
+    char stringpool_str1044[sizeof ("bin")];
+    char stringpool_str1046[sizeof ("i_fp_class")];
+    char stringpool_str1047[sizeof ("d_fp_class")];
+    char stringpool_str1049[sizeof ("grep")];
+    char stringpool_str1050[sizeof ("i_db")];
+    char stringpool_str1052[sizeof ("egrep")];
+    char stringpool_str1053[sizeof ("d_bsd")];
+    char stringpool_str1054[sizeof ("i_grp")];
+    char stringpool_str1057[sizeof ("bin_ELF")];
+    char stringpool_str1058[sizeof ("d_fp_classify")];
+    char stringpool_str1063[sizeof ("d_isfinite")];
+    char stringpool_str1064[sizeof ("d_tgamma")];
+    char stringpool_str1068[sizeof ("d_gmtime64")];
+    char stringpool_str1071[sizeof ("PERL_CONFIG_SH")];
+    char stringpool_str1076[sizeof ("d_fd_set")];
+    char stringpool_str1078[sizeof ("i_stddef")];
+    char stringpool_str1081[sizeof ("pager")];
+    char stringpool_str1083[sizeof ("i_sysndir")];
+    char stringpool_str1084[sizeof ("d_index")];
+    char stringpool_str1089[sizeof ("d_msgsnd")];
+    char stringpool_str1090[sizeof ("d_getmnt")];
+    char stringpool_str1099[sizeof ("tbl")];
+    char stringpool_str1102[sizeof ("libs")];
+    char stringpool_str1103[sizeof ("full_ar")];
+    char stringpool_str1106[sizeof ("d_fp_classl")];
+    char stringpool_str1111[sizeof ("d_fds_bits")];
+    char stringpool_str1115[sizeof ("i_utime")];
+    char stringpool_str1117[sizeof ("libsdirs")];
+    char stringpool_str1119[sizeof ("d_lgamma")];
+    char stringpool_str1122[sizeof ("d_isfinitel")];
+    char stringpool_str1123[sizeof ("d_finitel")];
+    char stringpool_str1124[sizeof ("RCSfile")];
     char stringpool_str1129[sizeof ("d_ilogb")];
-    char stringpool_str1134[sizeof ("yacc")];
-    char stringpool_str1135[sizeof ("longsize")];
-    char stringpool_str1137[sizeof ("d_setpent")];
-    char stringpool_str1140[sizeof ("d_endpent")];
-    char stringpool_str1148[sizeof ("d_gmtime64")];
-    char stringpool_str1149[sizeof ("i64size")];
-    char stringpool_str1150[sizeof ("d_atolf")];
-    char stringpool_str1153[sizeof ("d_lroundl")];
-    char stringpool_str1155[sizeof ("d_accessx")];
-    char stringpool_str1157[sizeof ("d_pause")];
-    char stringpool_str1164[sizeof ("d_procselfexe")];
-    char stringpool_str1166[sizeof ("usecrosscompile")];
-    char stringpool_str1169[sizeof ("d_PRIgldbl")];
-    char stringpool_str1175[sizeof ("i16size")];
-    char stringpool_str1179[sizeof ("i_stddef")];
-    char stringpool_str1180[sizeof ("d_fd_set")];
-    char stringpool_str1189[sizeof ("libperl")];
-    char stringpool_str1192[sizeof ("d_lgamma")];
-    char stringpool_str1193[sizeof ("full_ar")];
-    char stringpool_str1205[sizeof ("d_ilogbl")];
+    char stringpool_str1132[sizeof ("bison")];
+    char stringpool_str1133[sizeof ("i_float")];
+    char stringpool_str1135[sizeof ("d_procselfexe")];
+    char stringpool_str1138[sizeof ("d_memmem")];
+    char stringpool_str1141[sizeof ("sitebin")];
+    char stringpool_str1142[sizeof ("d_uname")];
+    char stringpool_str1145[sizeof ("usesfio")];
+    char stringpool_str1149[sizeof ("d_cmsghdr_s")];
+    char stringpool_str1154[sizeof ("d_setpent")];
+    char stringpool_str1157[sizeof ("d_endpent")];
+    char stringpool_str1161[sizeof ("i_sysin")];
+    char stringpool_str1162[sizeof ("ranlib")];
+    char stringpool_str1163[sizeof ("d_readdir64_r")];
+    char stringpool_str1168[sizeof ("nroff")];
+    char stringpool_str1169[sizeof ("troff")];
+    char stringpool_str1176[sizeof ("d_pause")];
+    char stringpool_str1178[sizeof ("d_PRIEUldbl")];
+    char stringpool_str1179[sizeof ("d_flockproto")];
+    char stringpool_str1180[sizeof ("d_PRIGUldbl")];
+    char stringpool_str1181[sizeof ("afsroot")];
+    char stringpool_str1184[sizeof ("seedfunc")];
+    char stringpool_str1185[sizeof ("d_PRIFUldbl")];
+    char stringpool_str1188[sizeof ("d_ilogbl")];
+    char stringpool_str1197[sizeof ("d_regcmp")];
+    char stringpool_str1200[sizeof ("i_dbm")];
+    char stringpool_str1202[sizeof ("d_PRIgldbl")];
+    char stringpool_str1203[sizeof ("i_ndbm")];
+    char stringpool_str1204[sizeof ("d_ndbm")];
     char stringpool_str1206[sizeof ("d_usleep")];
-    char stringpool_str1219[sizeof ("i8type")];
-    char stringpool_str1222[sizeof ("d_modfl")];
-    char stringpool_str1226[sizeof ("seedfunc")];
-    char stringpool_str1236[sizeof ("d_isfinite")];
-    char stringpool_str1237[sizeof ("i_utime")];
-    char stringpool_str1239[sizeof ("RCSfile")];
-    char stringpool_str1240[sizeof ("ptrsize")];
-    char stringpool_str1241[sizeof ("d_dirnamlen")];
-    char stringpool_str1243[sizeof ("i_inttypes")];
-    char stringpool_str1244[sizeof ("d_log2")];
-    char stringpool_str1245[sizeof ("d_finitel")];
-    char stringpool_str1255[sizeof ("randbits")];
-    char stringpool_str1256[sizeof ("i32size")];
-    char stringpool_str1262[sizeof ("d_uname")];
-    char stringpool_str1264[sizeof ("d_msgsnd")];
-    char stringpool_str1265[sizeof ("d_getmnt")];
-    char stringpool_str1266[sizeof ("randfunc")];
-    char stringpool_str1267[sizeof ("PERL_API_VERSION")];
-    char stringpool_str1268[sizeof ("PERL_API_REVISION")];
-    char stringpool_str1272[sizeof ("d_mblen")];
-    char stringpool_str1273[sizeof ("PERL_API_SUBVERSION")];
-    char stringpool_str1274[sizeof ("sig_num")];
-    char stringpool_str1280[sizeof ("d_flockproto")];
-    char stringpool_str1281[sizeof ("d_isnormal")];
-    char stringpool_str1290[sizeof ("d_signbit")];
-    char stringpool_str1304[sizeof ("sitelibexp")];
-    char stringpool_str1305[sizeof ("d_getitimer")];
-    char stringpool_str1309[sizeof ("i_sysin")];
-    char stringpool_str1312[sizeof ("d_isfinitel")];
-    char stringpool_str1314[sizeof ("i_stdbool")];
+    char stringpool_str1212[sizeof ("d_cbrt")];
+    char stringpool_str1220[sizeof ("d_ftime")];
+    char stringpool_str1228[sizeof ("d_msync")];
+    char stringpool_str1231[sizeof ("d_modflproto")];
+    char stringpool_str1235[sizeof ("d_sysernlst")];
+    char stringpool_str1236[sizeof ("libc")];
+    char stringpool_str1238[sizeof ("randfunc")];
+    char stringpool_str1239[sizeof ("d_msg_dontroute")];
+    char stringpool_str1247[sizeof ("sysman")];
+    char stringpool_str1252[sizeof ("d_inetaton")];
+    char stringpool_str1254[sizeof ("d_getprior")];
+    char stringpool_str1259[sizeof ("d_syserrlst")];
+    char stringpool_str1261[sizeof ("sPRIeldbl")];
+    char stringpool_str1269[sizeof ("rm_try")];
+    char stringpool_str1272[sizeof ("sig_num")];
+    char stringpool_str1280[sizeof ("inews")];
+    char stringpool_str1306[sizeof ("i8type")];
+    char stringpool_str1315[sizeof ("d_getitimer")];
     char stringpool_str1317[sizeof ("d_suidsafe")];
-    char stringpool_str1321[sizeof ("i_float")];
-    char stringpool_str1325[sizeof ("d_msync")];
-    char stringpool_str1326[sizeof ("sh")];
-    char stringpool_str1328[sizeof ("readdir64_r_proto")];
-    char stringpool_str1332[sizeof ("d_sysernlst")];
-    char stringpool_str1334[sizeof ("csh")];
-    char stringpool_str1336[sizeof ("hint")];
-    char stringpool_str1339[sizeof ("sysman")];
-    char stringpool_str1342[sizeof ("rm_try")];
-    char stringpool_str1344[sizeof ("d_syserrlst")];
-    char stringpool_str1346[sizeof ("d_csh")];
-    char stringpool_str1355[sizeof ("d_sendmsg")];
-    char stringpool_str1356[sizeof ("d_setegid")];
-    char stringpool_str1358[sizeof ("i_bfd")];
-    char stringpool_str1359[sizeof ("ld_can_script")];
-    char stringpool_str1364[sizeof ("d_fdclose")];
-    char stringpool_str1368[sizeof ("d_setrgid")];
-    char stringpool_str1369[sizeof ("nroff")];
-    char stringpool_str1370[sizeof ("troff")];
-    char stringpool_str1371[sizeof ("shar")];
-    char stringpool_str1372[sizeof ("d_chsize")];
-    char stringpool_str1376[sizeof ("stdchar")];
-    char stringpool_str1377[sizeof ("i_sgtty")];
-    char stringpool_str1380[sizeof ("d_msg_oob")];
-    char stringpool_str1385[sizeof ("d_ftime")];
-    char stringpool_str1387[sizeof ("cf_time")];
-    char stringpool_str1389[sizeof ("sitearch")];
-    char stringpool_str1392[sizeof ("d_cplusplus")];
-    char stringpool_str1394[sizeof ("d_prctl_set_name")];
-    char stringpool_str1405[sizeof ("charsize")];
-    char stringpool_str1412[sizeof ("i_bsdioctl")];
-    char stringpool_str1416[sizeof ("archname")];
-    char stringpool_str1419[sizeof ("submit")];
-    char stringpool_str1426[sizeof ("madlysrc")];
-    char stringpool_str1432[sizeof ("d_fpathconf")];
-    char stringpool_str1433[sizeof ("i_sunmath")];
-    char stringpool_str1435[sizeof ("d_bzero")];
-    char stringpool_str1437[sizeof ("netdb_net_type")];
-    char stringpool_str1443[sizeof ("useopcode")];
-    char stringpool_str1446[sizeof ("d_memmem")];
-    char stringpool_str1452[sizeof ("afsroot")];
-    char stringpool_str1454[sizeof ("incpth")];
-    char stringpool_str1463[sizeof ("d_setpgid")];
-    char stringpool_str1466[sizeof ("archlib")];
-    char stringpool_str1468[sizeof ("userelocatableinc")];
-    char stringpool_str1471[sizeof ("gzip")];
-    char stringpool_str1473[sizeof ("man3direxp")];
-    char stringpool_str1474[sizeof ("uidsign")];
-    char stringpool_str1484[sizeof ("d_uselocale")];
-    char stringpool_str1492[sizeof ("d_setgrent_r")];
-    char stringpool_str1495[sizeof ("d_endgrent_r")];
-    char stringpool_str1496[sizeof ("archname64")];
-    char stringpool_str1497[sizeof ("stdio_bufsiz")];
-    char stringpool_str1505[sizeof ("i_syssockio")];
-    char stringpool_str1507[sizeof ("man1direxp")];
-    char stringpool_str1508[sizeof ("d_msg_dontroute")];
-    char stringpool_str1510[sizeof ("doublesize")];
-    char stringpool_str1521[sizeof ("git_ancestor")];
-    char stringpool_str1528[sizeof ("ccflags")];
-    char stringpool_str1536[sizeof ("echo")];
-    char stringpool_str1550[sizeof ("uidsize")];
-    char stringpool_str1551[sizeof ("i_sysmman")];
-    char stringpool_str1552[sizeof ("d_shm")];
-    char stringpool_str1553[sizeof ("d_fpclass")];
-    char stringpool_str1554[sizeof ("d_modflproto")];
-    char stringpool_str1555[sizeof ("mips_type")];
-    char stringpool_str1556[sizeof ("stdio_stream_array")];
-    char stringpool_str1567[sizeof ("d_msgctl")];
-    char stringpool_str1572[sizeof ("u64size")];
-    char stringpool_str1583[sizeof ("i_math")];
-    char stringpool_str1584[sizeof ("d_castneg")];
-    char stringpool_str1594[sizeof ("ldflags")];
-    char stringpool_str1595[sizeof ("d_duplocale")];
-    char stringpool_str1596[sizeof ("asctime_r_proto")];
-    char stringpool_str1598[sizeof ("u16size")];
-    char stringpool_str1604[sizeof ("d_random_r")];
-    char stringpool_str1612[sizeof ("d_difftime")];
-    char stringpool_str1613[sizeof ("i_syspoll")];
-    char stringpool_str1616[sizeof ("d_archlib")];
-    char stringpool_str1617[sizeof ("i_machcthr")];
-    char stringpool_str1626[sizeof ("d_bcopy")];
-    char stringpool_str1629[sizeof ("d_fpclassl")];
-    char stringpool_str1630[sizeof ("d_fstatfs")];
-    char stringpool_str1637[sizeof ("d_semget")];
-    char stringpool_str1642[sizeof ("u8type")];
-    char stringpool_str1644[sizeof ("sSCNfldbl")];
-    char stringpool_str1650[sizeof ("libsfiles")];
-    char stringpool_str1660[sizeof ("i_crypt")];
-    char stringpool_str1661[sizeof ("d_crypt")];
-    char stringpool_str1662[sizeof ("sPRIfldbl")];
-    char stringpool_str1666[sizeof ("d_lc_monetary_2008")];
-    char stringpool_str1669[sizeof ("d_crypt_r")];
-    char stringpool_str1674[sizeof ("d_chroot")];
-    char stringpool_str1676[sizeof ("d_stdiobase")];
-    char stringpool_str1679[sizeof ("u32size")];
-    char stringpool_str1685[sizeof ("d_difftime64")];
-    char stringpool_str1686[sizeof ("d_fsync")];
-    char stringpool_str1690[sizeof ("d_sresgproto")];
-    char stringpool_str1691[sizeof ("uidformat")];
-    char stringpool_str1694[sizeof ("i_syssecrt")];
-    char stringpool_str1705[sizeof ("i_sysresrc")];
-    char stringpool_str1706[sizeof ("d_isblank")];
-    char stringpool_str1722[sizeof ("hostperl")];
-    char stringpool_str1726[sizeof ("i_sysaccess")];
-    char stringpool_str1730[sizeof ("i_sysioctl")];
-    char stringpool_str1732[sizeof ("i_sysun")];
-    char stringpool_str1733[sizeof ("i_memory")];
-    char stringpool_str1736[sizeof ("d_malloc_size")];
-    char stringpool_str1744[sizeof ("full_sed")];
-    char stringpool_str1747[sizeof ("d_munmap")];
-    char stringpool_str1749[sizeof ("prototype")];
-    char stringpool_str1753[sizeof ("chmod")];
-    char stringpool_str1758[sizeof ("d_htonl")];
-    char stringpool_str1759[sizeof ("ssizetype")];
-    char stringpool_str1766[sizeof ("i_sysselct")];
+    char stringpool_str1321[sizeof ("d_wait4")];
+    char stringpool_str1322[sizeof ("ebcdic")];
+    char stringpool_str1341[sizeof ("i_sysmman")];
+    char stringpool_str1343[sizeof ("d_mblen")];
+    char stringpool_str1344[sizeof ("d_readv")];
+    char stringpool_str1350[sizeof ("cf_time")];
+    char stringpool_str1352[sizeof ("d_isnormal")];
+    char stringpool_str1360[sizeof ("uidsign")];
+    char stringpool_str1361[sizeof ("readdir64_r_proto")];
+    char stringpool_str1362[sizeof ("yacc")];
+    char stringpool_str1372[sizeof ("d_setgrent_r")];
+    char stringpool_str1375[sizeof ("d_endgrent_r")];
+    char stringpool_str1376[sizeof ("sh")];
+    char stringpool_str1380[sizeof ("d_accessx")];
+    char stringpool_str1386[sizeof ("hint")];
+    char stringpool_str1392[sizeof ("d_dirnamlen")];
+    char stringpool_str1402[sizeof ("d_sendmsg")];
+    char stringpool_str1403[sizeof ("d_setegid")];
+    char stringpool_str1405[sizeof ("d_msg_oob")];
+    char stringpool_str1406[sizeof ("git_ancestor")];
+    char stringpool_str1416[sizeof ("d_signbit")];
+    char stringpool_str1427[sizeof ("d_setrgid")];
+    char stringpool_str1435[sizeof ("shar")];
+    char stringpool_str1438[sizeof ("d_rewinddir")];
+    char stringpool_str1445[sizeof ("madlysrc")];
+    char stringpool_str1449[sizeof ("d_fdclose")];
+    char stringpool_str1453[sizeof ("sitearch")];
+    char stringpool_str1457[sizeof ("i_memory")];
+    char stringpool_str1460[sizeof ("sitelibexp")];
+    char stringpool_str1465[sizeof ("libperl")];
+    char stringpool_str1466[sizeof ("i_pwd")];
+    char stringpool_str1470[sizeof ("man3direxp")];
+    char stringpool_str1475[sizeof ("man1direxp")];
+    char stringpool_str1477[sizeof ("i_stdbool")];
+    char stringpool_str1479[sizeof ("plibpth")];
+    char stringpool_str1496[sizeof ("d_setlocale")];
+    char stringpool_str1505[sizeof ("d_difftime")];
+    char stringpool_str1509[sizeof ("stdio_bufsiz")];
+    char stringpool_str1512[sizeof ("csh")];
+    char stringpool_str1513[sizeof ("stdio_stream_array")];
+    char stringpool_str1514[sizeof ("d_Gconvert")];
+    char stringpool_str1516[sizeof ("d_bcmp")];
+    char stringpool_str1520[sizeof ("ldflags")];
+    char stringpool_str1521[sizeof ("d_csh")];
+    char stringpool_str1525[sizeof ("d_fstatfs")];
+    char stringpool_str1528[sizeof ("d_semget")];
+    char stringpool_str1529[sizeof ("uidformat")];
+    char stringpool_str1533[sizeof ("randbits")];
+    char stringpool_str1534[sizeof ("d_chsize")];
+    char stringpool_str1535[sizeof ("d_shm")];
+    char stringpool_str1536[sizeof ("d_inc_version_list")];
+    char stringpool_str1538[sizeof ("d_difftime64")];
+    char stringpool_str1543[sizeof ("i_syssockio")];
+    char stringpool_str1551[sizeof ("useopcode")];
+    char stringpool_str1556[sizeof ("stdchar")];
+    char stringpool_str1561[sizeof ("asctime_r_proto")];
+    char stringpool_str1568[sizeof ("i_math")];
+    char stringpool_str1574[sizeof ("d_cplusplus")];
+    char stringpool_str1576[sizeof ("i_bfd")];
+    char stringpool_str1577[sizeof ("d_setproctitle")];
+    char stringpool_str1578[sizeof ("i_sysun")];
+    char stringpool_str1582[sizeof ("d_off64_t")];
+    char stringpool_str1584[sizeof ("charsize")];
+    char stringpool_str1585[sizeof ("d_setpgid")];
+    char stringpool_str1596[sizeof ("netdb_net_type")];
+    char stringpool_str1599[sizeof ("echo")];
+    char stringpool_str1603[sizeof ("full_sed")];
+    char stringpool_str1604[sizeof ("d_fsync")];
+    char stringpool_str1610[sizeof ("archname")];
+    char stringpool_str1611[sizeof ("d_fpathconf")];
+    char stringpool_str1612[sizeof ("d_msgctl")];
+    char stringpool_str1619[sizeof ("submit")];
+    char stringpool_str1623[sizeof ("d_getmntent")];
+    char stringpool_str1626[sizeof ("d_htonl")];
+    char stringpool_str1629[sizeof ("doublesize")];
+    char stringpool_str1630[sizeof ("i_sunmath")];
+    char stringpool_str1640[sizeof ("d_lc_monetary_2008")];
+    char stringpool_str1644[sizeof ("d_tm_tm_zone")];
+    char stringpool_str1645[sizeof ("d_dlsymun")];
+    char stringpool_str1646[sizeof ("d_castneg")];
+    char stringpool_str1649[sizeof ("i_syspoll")];
+    char stringpool_str1660[sizeof ("d_pseudofork")];
+    char stringpool_str1667[sizeof ("i_sysselct")];
+    char stringpool_str1670[sizeof ("archname64")];
+    char stringpool_str1678[sizeof ("hostosname")];
+    char stringpool_str1683[sizeof ("sysroot")];
+    char stringpool_str1695[sizeof ("d_timegm")];
+    char stringpool_str1707[sizeof ("incpth")];
+    char stringpool_str1715[sizeof ("hostperl")];
+    char stringpool_str1721[sizeof ("d_sresgproto")];
+    char stringpool_str1723[sizeof ("u8type")];
+    char stringpool_str1727[sizeof ("ccflags")];
+    char stringpool_str1738[sizeof ("d_wcscmp")];
+    char stringpool_str1740[sizeof ("i_syssecrt")];
+    char stringpool_str1742[sizeof ("i_machcthr")];
+    char stringpool_str1747[sizeof ("d_prctl_set_name")];
+    char stringpool_str1751[sizeof ("d_system")];
+    char stringpool_str1752[sizeof ("chmod")];
+    char stringpool_str1763[sizeof ("i_sysresrc")];
     char stringpool_str1768[sizeof ("doublekind")];
-    char stringpool_str1773[sizeof ("rd_nodata")];
-    char stringpool_str1775[sizeof ("d_stdio_stream_array")];
-    char stringpool_str1776[sizeof ("d_timegm")];
-    char stringpool_str1789[sizeof ("d_getgrps")];
-    char stringpool_str1792[sizeof ("d_fd_macros")];
-    char stringpool_str1793[sizeof ("glibpth")];
-    char stringpool_str1795[sizeof ("d_tm_tm_zone")];
-    char stringpool_str1805[sizeof ("d_pseudofork")];
-    char stringpool_str1807[sizeof ("usedtrace")];
-    char stringpool_str1808[sizeof ("strerror_r_proto")];
-    char stringpool_str1815[sizeof ("i64type")];
-    char stringpool_str1816[sizeof ("d_dlsymun")];
-    char stringpool_str1824[sizeof ("i_gdbm")];
-    char stringpool_str1827[sizeof ("d_setlocale_r")];
-    char stringpool_str1828[sizeof ("installusrbinperl")];
-    char stringpool_str1833[sizeof ("d_dir_dd_fd")];
-    char stringpool_str1841[sizeof ("i16type")];
-    char stringpool_str1847[sizeof ("d_getmntent")];
-    char stringpool_str1848[sizeof ("d_setsid")];
-    char stringpool_str1849[sizeof ("d_off64_t")];
-    char stringpool_str1854[sizeof ("d_getsent")];
-    char stringpool_str1855[sizeof ("d_getnent")];
-    char stringpool_str1859[sizeof ("d_j0")];
-    char stringpool_str1865[sizeof ("old_pthread_create_joinable")];
-    char stringpool_str1873[sizeof ("gidsign")];
-    char stringpool_str1879[sizeof ("d_siginfo_si_addr")];
-    char stringpool_str1880[sizeof ("sitehtml3dir")];
-    char stringpool_str1881[sizeof ("d_isascii")];
-    char stringpool_str1882[sizeof ("d_logb")];
-    char stringpool_str1883[sizeof ("d_getgrent")];
-    char stringpool_str1885[sizeof ("found_libucb")];
-    char stringpool_str1889[sizeof ("d_getfsstat")];
-    char stringpool_str1897[sizeof ("d_system")];
-    char stringpool_str1898[sizeof ("pidtype")];
-    char stringpool_str1899[sizeof ("d_casti32")];
-    char stringpool_str1900[sizeof ("byacc")];
-    char stringpool_str1908[sizeof ("aphostname")];
-    char stringpool_str1914[sizeof ("sPRIgldbl")];
-    char stringpool_str1922[sizeof ("i32type")];
-    char stringpool_str1924[sizeof ("usefaststdio")];
-    char stringpool_str1929[sizeof ("siteman3direxp")];
-    char stringpool_str1933[sizeof ("i_libutil")];
-    char stringpool_str1935[sizeof ("d_j0l")];
-    char stringpool_str1937[sizeof ("sysroot")];
-    char stringpool_str1943[sizeof ("d_siginfo_si_pid")];
-    char stringpool_str1948[sizeof ("d_setresgid")];
-    char stringpool_str1949[sizeof ("gidsize")];
-    char stringpool_str1952[sizeof ("d_setnetent_r")];
-    char stringpool_str1955[sizeof ("d_endnetent_r")];
-    char stringpool_str1957[sizeof ("cppsymbols")];
-    char stringpool_str1962[sizeof ("d_getpent")];
-    char stringpool_str1963[sizeof ("siteman1direxp")];
-    char stringpool_str1964[sizeof ("d_builtin_expect")];
-    char stringpool_str1965[sizeof ("touch")];
-    char stringpool_str1966[sizeof ("d_mymalloc")];
-    char stringpool_str1968[sizeof ("perl_static_inline")];
-    char stringpool_str1971[sizeof ("hostosname")];
-    char stringpool_str1974[sizeof ("Author")];
-    char stringpool_str1979[sizeof ("d_dbminitproto")];
-    char stringpool_str1986[sizeof ("d_shmdt")];
-    char stringpool_str1988[sizeof ("sitehtml1dir")];
-    char stringpool_str1991[sizeof ("i_sysstat")];
-    char stringpool_str1996[sizeof ("inews")];
-    char stringpool_str1997[sizeof ("hostcat")];
-    char stringpool_str2008[sizeof ("i_sysmode")];
-    char stringpool_str2010[sizeof ("d_shmat")];
-    char stringpool_str2011[sizeof ("d_hasmntopt")];
-    char stringpool_str2016[sizeof ("d_tcsetpgrp")];
-    char stringpool_str2049[sizeof ("d_readv")];
-    char stringpool_str2052[sizeof ("d_sysconf")];
-    char stringpool_str2054[sizeof ("vi")];
-    char stringpool_str2059[sizeof ("d_siginfo_si_errno")];
-    char stringpool_str2060[sizeof ("i_sysmount")];
-    char stringpool_str2061[sizeof ("d_semctl_semun")];
-    char stringpool_str2062[sizeof ("cppstdin")];
-    char stringpool_str2064[sizeof ("d_shmctl")];
-    char stringpool_str2072[sizeof ("i_pthread")];
-    char stringpool_str2073[sizeof ("d_wait4")];
-    char stringpool_str2078[sizeof ("d_semctl_semid_ds")];
-    char stringpool_str2079[sizeof ("d_msg_ctrunc")];
-    char stringpool_str2081[sizeof ("d_seteuid")];
-    char stringpool_str2082[sizeof ("d_statfs_s")];
-    char stringpool_str2085[sizeof ("byteorder")];
-    char stringpool_str2090[sizeof ("gidformat")];
-    char stringpool_str2091[sizeof ("d_portable")];
-    char stringpool_str2093[sizeof ("d_setruid")];
-    char stringpool_str2096[sizeof ("perlpath")];
-    char stringpool_str2097[sizeof ("d_sched_yield")];
-    char stringpool_str2102[sizeof ("d_longdbl")];
-    char stringpool_str2110[sizeof ("i_pwd")];
-    char stringpool_str2116[sizeof ("i_syslog")];
-    char stringpool_str2117[sizeof ("d_remainder")];
-    char stringpool_str2120[sizeof ("sitescript")];
-    char stringpool_str2122[sizeof ("bash")];
-    char stringpool_str2126[sizeof ("d_wcscmp")];
-    char stringpool_str2134[sizeof ("h_fcntl")];
-    char stringpool_str2136[sizeof ("d_fpclassify")];
-    char stringpool_str2137[sizeof ("d_sitearch")];
-    char stringpool_str2138[sizeof ("d_inc_version_list")];
-    char stringpool_str2142[sizeof ("sitescriptexp")];
-    char stringpool_str2145[sizeof ("d_fs_data_s")];
-    char stringpool_str2146[sizeof ("signal_t")];
-    char stringpool_str2153[sizeof ("sendmail")];
-    char stringpool_str2156[sizeof ("d_u32align")];
-    char stringpool_str2161[sizeof ("path_sep")];
-    char stringpool_str2163[sizeof ("sig_name_init")];
-    char stringpool_str2164[sizeof ("pthread_h_first")];
-    char stringpool_str2168[sizeof ("d_syscall")];
-    char stringpool_str2169[sizeof ("installsitebin")];
-    char stringpool_str2172[sizeof ("installman3dir")];
-    char stringpool_str2173[sizeof ("ccstdflags")];
-    char stringpool_str2179[sizeof ("Revision")];
-    char stringpool_str2183[sizeof ("d_fpos64_t")];
-    char stringpool_str2187[sizeof ("sitebinexp")];
-    char stringpool_str2192[sizeof ("revision")];
-    char stringpool_str2198[sizeof ("d_dbl_dig")];
-    char stringpool_str2206[sizeof ("installman1dir")];
-    char stringpool_str2211[sizeof ("targetsh")];
-    char stringpool_str2214[sizeof ("d_vendorbin")];
-    char stringpool_str2216[sizeof ("uidtype")];
-    char stringpool_str2218[sizeof ("d_Gconvert")];
-    char stringpool_str2227[sizeof ("d_seekdir")];
-    char stringpool_str2229[sizeof ("d_inetpton")];
-    char stringpool_str2232[sizeof ("d_strtoq")];
-    char stringpool_str2234[sizeof ("setnetent_r_proto")];
-    char stringpool_str2235[sizeof ("cppflags")];
-    char stringpool_str2237[sizeof ("endnetent_r_proto")];
-    char stringpool_str2238[sizeof ("u64type")];
-    char stringpool_str2248[sizeof ("d_rewinddir")];
-    char stringpool_str2249[sizeof ("d_fchmod")];
-    char stringpool_str2251[sizeof ("cccdlflags")];
-    char stringpool_str2253[sizeof ("i_gdbmndbm")];
-    char stringpool_str2261[sizeof ("d_siginfo_si_uid")];
-    char stringpool_str2263[sizeof ("mv")];
-    char stringpool_str2264[sizeof ("u16type")];
-    char stringpool_str2267[sizeof ("i_termio")];
-    char stringpool_str2268[sizeof ("privlib")];
-    char stringpool_str2271[sizeof ("i_termios")];
-    char stringpool_str2272[sizeof ("osvers")];
-    char stringpool_str2276[sizeof ("ccsymbols")];
-    char stringpool_str2280[sizeof ("d_nl_langinfo")];
-    char stringpool_str2282[sizeof ("d_gmtime_r")];
-    char stringpool_str2284[sizeof ("chgrp")];
-    char stringpool_str2285[sizeof ("libpth")];
-    char stringpool_str2288[sizeof ("d_getpgid")];
-    char stringpool_str2291[sizeof ("d_siginfo_si_status")];
-    char stringpool_str2292[sizeof ("castflags")];
-    char stringpool_str2293[sizeof ("d_link")];
-    char stringpool_str2306[sizeof ("d_vendorscript")];
-    char stringpool_str2312[sizeof ("spitshell")];
-    char stringpool_str2314[sizeof ("installsiteman3dir")];
-    char stringpool_str2315[sizeof ("stdio_ptr")];
-    char stringpool_str2317[sizeof ("d_getgrent_r")];
-    char stringpool_str2323[sizeof ("i_systypes")];
-    char stringpool_str2332[sizeof ("d_sqrtl")];
-    char stringpool_str2336[sizeof ("d_setproctitle")];
-    char stringpool_str2343[sizeof ("d_wcstombs")];
-    char stringpool_str2345[sizeof ("u32type")];
-    char stringpool_str2346[sizeof ("ccdlflags")];
-    char stringpool_str2347[sizeof ("static_ext")];
-    char stringpool_str2348[sizeof ("installsiteman1dir")];
-    char stringpool_str2351[sizeof ("d_sethent")];
-    char stringpool_str2354[sizeof ("d_endhent")];
-    char stringpool_str2359[sizeof ("groupcat")];
-    char stringpool_str2370[sizeof ("eunicefix")];
-    char stringpool_str2382[sizeof ("d_tm_tm_gmtoff")];
-    char stringpool_str2384[sizeof ("d_clearenv")];
-    char stringpool_str2386[sizeof ("usethreads")];
-    char stringpool_str2389[sizeof ("_exe")];
-    char stringpool_str2395[sizeof ("locincpth")];
-    char stringpool_str2401[sizeof ("d_locconv")];
-    char stringpool_str2403[sizeof ("d_siginfo_si_fd")];
-    char stringpool_str2406[sizeof ("d_lgamma_r")];
-    char stringpool_str2407[sizeof ("d_gethname")];
-    char stringpool_str2410[sizeof ("installhtml3dir")];
-    char stringpool_str2412[sizeof ("lddlflags")];
-    char stringpool_str2415[sizeof ("d_sresuproto")];
-    char stringpool_str2417[sizeof ("installhtml1dir")];
-    char stringpool_str2418[sizeof ("d_getnameinfo")];
-    char stringpool_str2423[sizeof ("i_socks")];
-    char stringpool_str2428[sizeof ("sockethdr")];
-    char stringpool_str2431[sizeof ("extras")];
-    char stringpool_str2432[sizeof ("Locker")];
-    char stringpool_str2435[sizeof ("d_llround")];
-    char stringpool_str2436[sizeof ("d_mkdir")];
-    char stringpool_str2437[sizeof ("mkdir")];
-    char stringpool_str2438[sizeof ("d_mktime")];
-    char stringpool_str2439[sizeof ("sGMTIME_max")];
-    char stringpool_str2443[sizeof ("cf_by")];
-    char stringpool_str2444[sizeof ("make")];
-    char stringpool_str2453[sizeof ("d_re_comp")];
-    char stringpool_str2457[sizeof ("sPRIx64")];
-    char stringpool_str2459[sizeof ("d_freelocale")];
-    char stringpool_str2461[sizeof ("d_msgget")];
-    char stringpool_str2463[sizeof ("d_pathconf")];
-    char stringpool_str2466[sizeof ("dlext")];
-    char stringpool_str2469[sizeof ("stdio_filbuf")];
-    char stringpool_str2474[sizeof ("d_dosuid")];
-    char stringpool_str2476[sizeof ("version")];
-    char stringpool_str2480[sizeof ("d_stdstdio")];
-    char stringpool_str2491[sizeof ("vendorbin")];
-    char stringpool_str2493[sizeof ("d_old_pthread_create_joinable")];
-    char stringpool_str2495[sizeof ("d_PRIx64")];
-    char stringpool_str2497[sizeof ("full_csh")];
-    char stringpool_str2501[sizeof ("cppminus")];
-    char stringpool_str2504[sizeof ("vendorlib")];
-    char stringpool_str2505[sizeof ("expr")];
-    char stringpool_str2510[sizeof ("d_syscallproto")];
-    char stringpool_str2511[sizeof ("d_llroundl")];
-    char stringpool_str2517[sizeof ("d_semop")];
-    char stringpool_str2518[sizeof ("d_mktime64")];
-    char stringpool_str2519[sizeof ("vaproto")];
-    char stringpool_str2521[sizeof ("uniq")];
-    char stringpool_str2531[sizeof ("sLOCALTIME_max")];
-    char stringpool_str2534[sizeof ("d_getprotoprotos")];
-    char stringpool_str2536[sizeof ("scriptdirexp")];
-    char stringpool_str2537[sizeof ("d_tmpnam_r")];
-    char stringpool_str2540[sizeof ("sched_yield")];
-    char stringpool_str2545[sizeof ("useithreads")];
-    char stringpool_str2552[sizeof ("myuname")];
-    char stringpool_str2554[sizeof ("pmake")];
-    char stringpool_str2558[sizeof ("d_getnetbyname_r")];
-    char stringpool_str2561[sizeof ("d_quad")];
-    char stringpool_str2562[sizeof ("d_longlong")];
-    char stringpool_str2563[sizeof ("doublemantbits")];
-    char stringpool_str2568[sizeof ("i_sysstatfs")];
-    char stringpool_str2573[sizeof ("op_cflags")];
-    char stringpool_str2578[sizeof ("charbits")];
-    char stringpool_str2581[sizeof ("ansi2knr")];
-    char stringpool_str2591[sizeof ("nvsize")];
-    char stringpool_str2593[sizeof ("ivsize")];
-    char stringpool_str2597[sizeof ("i_arpainet")];
-    char stringpool_str2606[sizeof ("vendorman3dir")];
-    char stringpool_str2614[sizeof ("d_statvfs")];
-    char stringpool_str2615[sizeof ("gidtype")];
-    char stringpool_str2617[sizeof ("d_localtime64")];
-    char stringpool_str2627[sizeof ("d_siginfo_si_band")];
-    char stringpool_str2630[sizeof ("d_exp2")];
-    char stringpool_str2640[sizeof ("vendorman1dir")];
-    char stringpool_str2641[sizeof ("i_fenv")];
-    char stringpool_str2642[sizeof ("socketlib")];
-    char stringpool_str2650[sizeof ("setprotoent_r_proto")];
-    char stringpool_str2653[sizeof ("endprotoent_r_proto")];
-    char stringpool_str2666[sizeof ("installarchlib")];
-    char stringpool_str2667[sizeof ("archlibexp")];
-    char stringpool_str2673[sizeof ("d_setresuid")];
-    char stringpool_str2676[sizeof ("ttyname_r_proto")];
-    char stringpool_str2677[sizeof ("usereentrant")];
-    char stringpool_str2683[sizeof ("d_readlink")];
-    char stringpool_str2684[sizeof ("i_stdlib")];
-    char stringpool_str2685[sizeof ("d_asctime_r")];
-    char stringpool_str2687[sizeof ("d_ttyname_r")];
-    char stringpool_str2688[sizeof ("setgrent_r_proto")];
-    char stringpool_str2691[sizeof ("endgrent_r_proto")];
-    char stringpool_str2697[sizeof ("d_asctime64")];
-    char stringpool_str2702[sizeof ("mailx")];
-    char stringpool_str2714[sizeof ("d_closedir")];
-    char stringpool_str2716[sizeof ("d_setpwent")];
-    char stringpool_str2719[sizeof ("d_endpwent")];
-    char stringpool_str2731[sizeof ("cf_email")];
-    char stringpool_str2738[sizeof ("madlyh")];
-    char stringpool_str2741[sizeof ("libspath")];
-    char stringpool_str2746[sizeof ("nvmantbits")];
-    char stringpool_str2755[sizeof ("d_copysign")];
-    char stringpool_str2777[sizeof ("d_getnetent_r")];
-    char stringpool_str2785[sizeof ("db_hashtype")];
-    char stringpool_str2792[sizeof ("shmattype")];
-    char stringpool_str2802[sizeof ("baserev")];
-    char stringpool_str2817[sizeof ("alignbytes")];
-    char stringpool_str2826[sizeof ("d_getprotobyname_r")];
-    char stringpool_str2831[sizeof ("d_copysignl")];
-    char stringpool_str2841[sizeof ("d_tcgetpgrp")];
-    char stringpool_str2844[sizeof ("d_expm1")];
-    char stringpool_str2848[sizeof ("d_socklen_t")];
-    char stringpool_str2864[sizeof ("d_setreuid")];
-    char stringpool_str2870[sizeof ("git_remote_branch")];
-    char stringpool_str2886[sizeof ("d_fsetpos")];
-    char stringpool_str2889[sizeof ("d_sin6_scope_id")];
-    char stringpool_str2901[sizeof ("orderlib")];
-    char stringpool_str2909[sizeof ("d_sigaction")];
-    char stringpool_str2914[sizeof ("d_getpbynumber")];
-    char stringpool_str2916[sizeof ("myarchname")];
-    char stringpool_str2920[sizeof ("setlocale_r_proto")];
-    char stringpool_str2922[sizeof ("installbin")];
-    char stringpool_str2927[sizeof ("i_vfork")];
-    char stringpool_str2928[sizeof ("d_vfork")];
-    char stringpool_str2943[sizeof ("i_sysdir")];
-    char stringpool_str2958[sizeof ("d_shmget")];
-    char stringpool_str2960[sizeof ("git_describe")];
-    char stringpool_str2961[sizeof ("d_pwclass")];
-    char stringpool_str2963[sizeof ("d_vsnprintf")];
-    char stringpool_str2967[sizeof ("d_snprintf")];
-    char stringpool_str2968[sizeof ("i_varargs")];
-    char stringpool_str2974[sizeof ("i_sysparam")];
-    char stringpool_str2977[sizeof ("d_wctomb")];
-    char stringpool_str2982[sizeof ("d_sprintf_returns_strlen")];
-    char stringpool_str2985[sizeof ("d_nearbyint")];
-    char stringpool_str2994[sizeof ("targetarch")];
-    char stringpool_str2996[sizeof ("fflushNULL")];
-    char stringpool_str2999[sizeof ("d_socket")];
-    char stringpool_str3000[sizeof ("d_fork")];
-    char stringpool_str3016[sizeof ("uvsize")];
-    char stringpool_str3018[sizeof ("d_volatile")];
-    char stringpool_str3020[sizeof ("d_oldpthreads")];
-    char stringpool_str3030[sizeof ("doop_cflags")];
-    char stringpool_str3031[sizeof ("flex")];
-    char stringpool_str3032[sizeof ("gccversion")];
-    char stringpool_str3039[sizeof ("getprotobyname_r_proto")];
-    char stringpool_str3040[sizeof ("d_newlocale")];
-    char stringpool_str3049[sizeof ("d_getppid")];
-    char stringpool_str3054[sizeof ("d_gethostprotos")];
-    char stringpool_str3059[sizeof ("getnetent_r_proto")];
-    char stringpool_str3060[sizeof ("selectminbits")];
-    char stringpool_str3063[sizeof ("d_phostname")];
-    char stringpool_str3067[sizeof ("man3ext")];
-    char stringpool_str3070[sizeof ("myhostname")];
-    char stringpool_str3073[sizeof ("d_setprotoent_r")];
-    char stringpool_str3076[sizeof ("d_endprotoent_r")];
-    char stringpool_str3080[sizeof ("d_stdio_cnt_lval")];
-    char stringpool_str3082[sizeof ("d_getpagsz")];
-    char stringpool_str3085[sizeof ("prefix")];
-    char stringpool_str3090[sizeof ("longdblmantbits")];
-    char stringpool_str3092[sizeof ("d_getgrnam_r")];
-    char stringpool_str3099[sizeof ("d_mbstowcs")];
-    char stringpool_str3101[sizeof ("man1ext")];
-    char stringpool_str3105[sizeof ("netdb_host_type")];
-    char stringpool_str3106[sizeof ("targetmkdir")];
-    char stringpool_str3113[sizeof ("d_pwcomment")];
-    char stringpool_str3120[sizeof ("i_rpcsvcdbm")];
-    char stringpool_str3124[sizeof ("installvendorscript")];
-    char stringpool_str3125[sizeof ("d_msgrcv")];
-    char stringpool_str3128[sizeof ("netdb_name_type")];
-    char stringpool_str3129[sizeof ("d_unsetenv")];
-    char stringpool_str3130[sizeof ("installsitelib")];
-    char stringpool_str3138[sizeof ("sethostent_r_proto")];
-    char stringpool_str3141[sizeof ("endhostent_r_proto")];
-    char stringpool_str3142[sizeof ("usedevel")];
-    char stringpool_str3146[sizeof ("d_pwgecos")];
-    char stringpool_str3150[sizeof ("d_setpwent_r")];
-    char stringpool_str3151[sizeof ("d_getnbyaddr")];
-    char stringpool_str3153[sizeof ("d_endpwent_r")];
-    char stringpool_str3162[sizeof ("need_va_copy")];
-    char stringpool_str3163[sizeof ("d_hypot")];
-    char stringpool_str3171[sizeof ("i_values")];
-    char stringpool_str3174[sizeof ("git_commit_id")];
-    char stringpool_str3175[sizeof ("targetport")];
-    char stringpool_str3176[sizeof ("d_gethent")];
-    char stringpool_str3179[sizeof ("usemallocwrap")];
-    char stringpool_str3183[sizeof ("d_vendorlib")];
-    char stringpool_str3186[sizeof ("setservent_r_proto")];
-    char stringpool_str3189[sizeof ("endservent_r_proto")];
-    char stringpool_str3199[sizeof ("phostname")];
-    char stringpool_str3208[sizeof ("d_fmax")];
-    char stringpool_str3214[sizeof ("usemymalloc")];
-    char stringpool_str3219[sizeof ("installhtmldir")];
-    char stringpool_str3220[sizeof ("vendorhtml3dir")];
-    char stringpool_str3222[sizeof ("ieeefp_h")];
-    char stringpool_str3223[sizeof ("d_vprintf")];
-    char stringpool_str3224[sizeof ("random_r_proto")];
-    char stringpool_str3226[sizeof ("loclibpth")];
-    char stringpool_str3231[sizeof ("d_fegetround")];
-    char stringpool_str3234[sizeof ("d_voidtty")];
-    char stringpool_str3237[sizeof ("d_getcwd")];
-    char stringpool_str3241[sizeof ("d_sockatmark")];
-    char stringpool_str3243[sizeof ("d_c99_variadic_macros")];
-    char stringpool_str3247[sizeof ("d_log1p")];
-    char stringpool_str3250[sizeof ("installvendorman3dir")];
-    char stringpool_str3252[sizeof ("installstyle")];
-    char stringpool_str3254[sizeof ("vendorhtml1dir")];
-    char stringpool_str3255[sizeof ("d_strxfrm")];
-    char stringpool_str3257[sizeof ("nvtype")];
-    char stringpool_str3259[sizeof ("ivtype")];
-    char stringpool_str3263[sizeof ("d_setregid")];
-    char stringpool_str3264[sizeof ("binexp")];
-    char stringpool_str3270[sizeof ("git_commit_id_title")];
-    char stringpool_str3271[sizeof ("gmake")];
-    char stringpool_str3274[sizeof ("d_regcomp")];
-    char stringpool_str3283[sizeof ("defvoidused")];
-    char stringpool_str3284[sizeof ("installvendorman1dir")];
-    char stringpool_str3285[sizeof ("issymlink")];
-    char stringpool_str3290[sizeof ("d_symlink")];
-    char stringpool_str3294[sizeof ("d_static_inline")];
-    char stringpool_str3303[sizeof ("db_version_minor")];
-    char stringpool_str3306[sizeof ("d_sockaddr_in6")];
-    char stringpool_str3307[sizeof ("nveformat")];
-    char stringpool_str3310[sizeof ("api_subversion")];
-    char stringpool_str3312[sizeof ("ivdformat")];
-    char stringpool_str3314[sizeof ("d_malloc_good_size")];
-    char stringpool_str3321[sizeof ("d_lockf")];
-    char stringpool_str3323[sizeof ("cppccsymbols")];
-    char stringpool_str3326[sizeof ("d_pthread_yield")];
-    char stringpool_str3330[sizeof ("tmpnam_r_proto")];
-    char stringpool_str3333[sizeof ("d_setvbuf")];
-    char stringpool_str3338[sizeof ("d_fpgetround")];
-    char stringpool_str3343[sizeof ("xlibpth")];
-    char stringpool_str3348[sizeof ("d_localtime_r")];
-    char stringpool_str3376[sizeof ("d_localtime_r_needs_tzset")];
-    char stringpool_str3378[sizeof ("d_ptrdiff_t")];
-    char stringpool_str3382[sizeof ("yaccflags")];
-    char stringpool_str3383[sizeof ("d_grpasswd")];
-    char stringpool_str3385[sizeof ("subversion")];
-    char stringpool_str3391[sizeof ("d_memmove")];
-    char stringpool_str3406[sizeof ("timetype")];
-    char stringpool_str3416[sizeof ("d_recvmsg")];
-    char stringpool_str3418[sizeof ("d_getnetbyaddr_r")];
-    char stringpool_str3440[sizeof ("shrpenv")];
-    char stringpool_str3442[sizeof ("madlyobj")];
-    char stringpool_str3444[sizeof ("targetenv")];
-    char stringpool_str3447[sizeof ("i_varhdr")];
-    char stringpool_str3455[sizeof ("d_union_semun")];
-    char stringpool_str3459[sizeof ("d_sigprocmask")];
-    char stringpool_str3466[sizeof ("i_shadow")];
-    char stringpool_str3468[sizeof ("installprivlib")];
-    char stringpool_str3469[sizeof ("privlibexp")];
-    char stringpool_str3470[sizeof ("html3dir")];
-    char stringpool_str3475[sizeof ("getprotoent_r_proto")];
-    char stringpool_str3483[sizeof ("d_getespwnam")];
-    char stringpool_str3488[sizeof ("d_xenix")];
-    char stringpool_str3496[sizeof ("getnetbyaddr_r_proto")];
-    char stringpool_str3499[sizeof ("lseektype")];
-    char stringpool_str3501[sizeof ("installsitearch")];
-    char stringpool_str3504[sizeof ("html1dir")];
-    char stringpool_str3507[sizeof ("ccflags_nolargefiles")];
-    char stringpool_str3513[sizeof ("getgrent_r_proto")];
-    char stringpool_str3519[sizeof ("chown")];
-    char stringpool_str3523[sizeof ("ksh")];
-    char stringpool_str3526[sizeof ("d_statfs_f_flags")];
-    char stringpool_str3529[sizeof ("sig_count")];
-    char stringpool_str3537[sizeof ("d_pwage")];
-    char stringpool_str3541[sizeof ("d_getpwent")];
-    char stringpool_str3544[sizeof ("d_shmatprototype")];
-    char stringpool_str3549[sizeof ("uselongdouble")];
-    char stringpool_str3550[sizeof ("netdb_hlen_type")];
-    char stringpool_str3551[sizeof ("i_sysuio")];
-    char stringpool_str3555[sizeof ("d_setpgrp")];
-    char stringpool_str3558[sizeof ("getspnam_r_proto")];
-    char stringpool_str3573[sizeof ("ldflags_nolargefiles")];
-    char stringpool_str3575[sizeof ("mydomain")];
-    char stringpool_str3582[sizeof ("d_mbtowc")];
-    char stringpool_str3588[sizeof ("d_getprpwnam")];
-    char stringpool_str3590[sizeof ("randseedtype")];
-    char stringpool_str3591[sizeof ("installprefixexp")];
-    char stringpool_str3598[sizeof ("d_msghdr_s")];
-    char stringpool_str3604[sizeof ("modetype")];
-    char stringpool_str3606[sizeof ("d_voidsig")];
-    char stringpool_str3607[sizeof ("extern_C")];
-    char stringpool_str3624[sizeof ("d_memcpy")];
-    char stringpool_str3635[sizeof ("usesitecustomize")];
-    char stringpool_str3640[sizeof ("longdblnanbytes")];
-    char stringpool_str3648[sizeof ("libswanted")];
-    char stringpool_str3649[sizeof ("longdblinfbytes")];
-    char stringpool_str3650[sizeof ("d_strctcpy")];
-    char stringpool_str3661[sizeof ("lib_ext")];
-    char stringpool_str3663[sizeof ("d_sockatmarkproto")];
-    char stringpool_str3665[sizeof ("d_gettimeod")];
-    char stringpool_str3678[sizeof ("mallocobj")];
-    char stringpool_str3679[sizeof ("config_args")];
-    char stringpool_str3680[sizeof ("libsfound")];
-    char stringpool_str3681[sizeof ("d_getlogin")];
-    char stringpool_str3682[sizeof ("uvtype")];
-    char stringpool_str3683[sizeof ("d_setpgrp2")];
-    char stringpool_str3685[sizeof ("config_argc")];
-    char stringpool_str3686[sizeof ("config_arg8")];
-    char stringpool_str3689[sizeof ("config_arg3")];
-    char stringpool_str3690[sizeof ("config_arg6")];
-    char stringpool_str3691[sizeof ("cpp_stuff")];
-    char stringpool_str3692[sizeof ("config_arg39")];
-    char stringpool_str3693[sizeof ("d_setlinebuf")];
-    char stringpool_str3697[sizeof ("config_arg4")];
-    char stringpool_str3698[sizeof ("config_arg35")];
-    char stringpool_str3699[sizeof ("config_arg38")];
-    char stringpool_str3700[sizeof ("selecttype")];
-    char stringpool_str3701[sizeof ("config_arg30")];
-    char stringpool_str3702[sizeof ("config_arg33")];
-    char stringpool_str3704[sizeof ("spackage")];
-    char stringpool_str3705[sizeof ("config_arg0")];
-    char stringpool_str3706[sizeof ("config_arg37")];
-    char stringpool_str3708[sizeof ("clocktype")];
-    char stringpool_str3709[sizeof ("config_arg31")];
-    char stringpool_str3711[sizeof ("d_fgetpos")];
-    char stringpool_str3712[sizeof ("config_arg9")];
-    char stringpool_str3713[sizeof ("d_getsbyname")];
-    char stringpool_str3714[sizeof ("d_getnbyname")];
-    char stringpool_str3715[sizeof ("i_systime")];
-    char stringpool_str3716[sizeof ("config_arg5")];
-    char stringpool_str3717[sizeof ("i_systimes")];
-    char stringpool_str3719[sizeof ("sizetype")];
-    char stringpool_str3722[sizeof ("git_branch")];
-    char stringpool_str3723[sizeof ("config_arg1")];
-    char stringpool_str3724[sizeof ("config_arg36")];
-    char stringpool_str3726[sizeof ("config_arg19")];
-    char stringpool_str3728[sizeof ("config_arg32")];
-    char stringpool_str3729[sizeof ("d_chown")];
-    char stringpool_str3730[sizeof ("i_sysutsname")];
-    char stringpool_str3732[sizeof ("config_arg15")];
-    char stringpool_str3733[sizeof ("config_arg18")];
-    char stringpool_str3735[sizeof ("config_arg10")];
-    char stringpool_str3736[sizeof ("config_arg13")];
-    char stringpool_str3737[sizeof ("config_arg7")];
-    char stringpool_str3740[sizeof ("config_arg17")];
-    char stringpool_str3743[sizeof ("config_arg11")];
-    char stringpool_str3747[sizeof ("d_socks5_init")];
-    char stringpool_str3748[sizeof ("mmaptype")];
-    char stringpool_str3749[sizeof ("config_arg34")];
-    char stringpool_str3757[sizeof ("installvendorbin")];
-    char stringpool_str3758[sizeof ("config_arg16")];
-    char stringpool_str3759[sizeof ("d_fchdir")];
-    char stringpool_str3762[sizeof ("config_arg12")];
-    char stringpool_str3765[sizeof ("d_getservprotos")];
-    char stringpool_str3773[sizeof ("st_ino_size")];
-    char stringpool_str3776[sizeof ("freetype")];
-    char stringpool_str3777[sizeof ("package")];
-    char stringpool_str3783[sizeof ("config_arg14")];
-    char stringpool_str3785[sizeof ("lkflags")];
-    char stringpool_str3797[sizeof ("i_langinfo")];
-    char stringpool_str3798[sizeof ("o_nonblock")];
-    char stringpool_str3805[sizeof ("config_arg2")];
-    char stringpool_str3806[sizeof ("d_safemcpy")];
-    char stringpool_str3808[sizeof ("config_arg29")];
-    char stringpool_str3811[sizeof ("d_safebcpy")];
-    char stringpool_str3814[sizeof ("config_arg25")];
-    char stringpool_str3815[sizeof ("config_arg28")];
-    char stringpool_str3817[sizeof ("config_arg20")];
-    char stringpool_str3818[sizeof ("config_arg23")];
-    char stringpool_str3819[sizeof ("nvGUformat")];
-    char stringpool_str3820[sizeof ("nvEUformat")];
-    char stringpool_str3821[sizeof ("d_getpbyname")];
-    char stringpool_str3822[sizeof ("config_arg27")];
-    char stringpool_str3824[sizeof ("nvFUformat")];
-    char stringpool_str3825[sizeof ("config_arg21")];
-    char stringpool_str3830[sizeof ("installvendorlib")];
-    char stringpool_str3840[sizeof ("config_arg26")];
-    char stringpool_str3844[sizeof ("config_arg22")];
-    char stringpool_str3865[sizeof ("config_arg24")];
-    char stringpool_str3879[sizeof ("nvfformat")];
-    char stringpool_str3886[sizeof ("cryptlib")];
-    char stringpool_str3890[sizeof ("d_sethostent_r")];
-    char stringpool_str3893[sizeof ("d_endhostent_r")];
-    char stringpool_str3898[sizeof ("d_getprotoent_r")];
-    char stringpool_str3900[sizeof ("perl_patchlevel")];
-    char stringpool_str3906[sizeof ("regexec_cflags")];
-    char stringpool_str3916[sizeof ("d_getspnam")];
-    char stringpool_str3921[sizeof ("db_prefixtype")];
-    char stringpool_str3925[sizeof ("hostgenerate")];
-    char stringpool_str3929[sizeof ("d_fstatvfs")];
-    char stringpool_str3930[sizeof ("uvoformat")];
-    char stringpool_str3932[sizeof ("git_commit_date")];
-    char stringpool_str3937[sizeof ("d_gnulibc")];
-    char stringpool_str3939[sizeof ("setpwent_r_proto")];
-    char stringpool_str3942[sizeof ("endpwent_r_proto")];
-    char stringpool_str3948[sizeof ("d_sigsetjmp")];
-    char stringpool_str3963[sizeof ("gethostent_r_proto")];
-    char stringpool_str3973[sizeof ("use64bitall")];
-    char stringpool_str3975[sizeof ("d_getpwent_r")];
-    char stringpool_str3981[sizeof ("i_sysvfs")];
-    char stringpool_str3986[sizeof ("d_getprotobynumber_r")];
-    char stringpool_str4001[sizeof ("d_lchown")];
-    char stringpool_str4009[sizeof ("i_gdbm_ndbm")];
-    char stringpool_str4011[sizeof ("getservent_r_proto")];
-    char stringpool_str4022[sizeof ("gmtime_r_proto")];
-    char stringpool_str4025[sizeof ("d_printf_format_null")];
-    char stringpool_str4029[sizeof ("usemorebits")];
-    char stringpool_str4031[sizeof ("d_mkfifo")];
-    char stringpool_str4034[sizeof ("d_fcntl_can_lock")];
-    char stringpool_str4036[sizeof ("fflushall")];
-    char stringpool_str4042[sizeof ("versiononly")];
-    char stringpool_str4059[sizeof ("getnetbyname_r_proto")];
-    char stringpool_str4063[sizeof ("libs_nolargefiles")];
-    char stringpool_str4068[sizeof ("fpostype")];
-    char stringpool_str4071[sizeof ("st_ino_sign")];
-    char stringpool_str4076[sizeof ("direntrytype")];
-    char stringpool_str4083[sizeof ("procselfexe")];
-    char stringpool_str4090[sizeof ("i_xlocale")];
-    char stringpool_str4114[sizeof ("uselargefiles")];
-    char stringpool_str4115[sizeof ("d_getlogin_r")];
-    char stringpool_str4127[sizeof ("d_waitpid")];
-    char stringpool_str4128[sizeof ("d_pthread_attr_setscope")];
-    char stringpool_str4131[sizeof ("nvgformat")];
-    char stringpool_str4148[sizeof ("i_sysfile")];
-    char stringpool_str4157[sizeof ("uvuformat")];
-    char stringpool_str4186[sizeof ("d_nextafter")];
-    char stringpool_str4187[sizeof ("canned_gperf")];
-    char stringpool_str4195[sizeof ("uquadtype")];
-    char stringpool_str4209[sizeof ("malloctype")];
-    char stringpool_str4210[sizeof ("awk")];
-    char stringpool_str4212[sizeof ("localtime_r_proto")];
-    char stringpool_str4230[sizeof ("api_version")];
-    char stringpool_str4233[sizeof ("d_backtrace")];
-    char stringpool_str4244[sizeof ("uvXUformat")];
-    char stringpool_str4274[sizeof ("longlongsize")];
-    char stringpool_str4285[sizeof ("i_syswait")];
-    char stringpool_str4288[sizeof ("getgrnam_r_proto")];
-    char stringpool_str4296[sizeof ("d_bsdsetpgrp")];
-    char stringpool_str4306[sizeof ("ccversion")];
-    char stringpool_str4312[sizeof ("db_version_patch")];
-    char stringpool_str4314[sizeof ("dynamic_ext")];
-    char stringpool_str4340[sizeof ("sharpbang")];
-    char stringpool_str4345[sizeof ("i_quadmath")];
-    char stringpool_str4346[sizeof ("installsitescript")];
-    char stringpool_str4350[sizeof ("d_getspnam_r")];
-    char stringpool_str4351[sizeof ("d_builtin_choose_expr")];
-    char stringpool_str4360[sizeof ("installvendorarch")];
-    char stringpool_str4368[sizeof ("sitehtml3direxp")];
-    char stringpool_str4380[sizeof ("d_getpgrp")];
-    char stringpool_str4383[sizeof ("gethostbyname_r_proto")];
-    char stringpool_str4388[sizeof ("vendorarch")];
-    char stringpool_str4389[sizeof ("vendorscript")];
-    char stringpool_str4408[sizeof ("d_siginfo_si_value")];
-    char stringpool_str4410[sizeof ("vendorarchexp")];
-    char stringpool_str4411[sizeof ("d_vms_case_sensitive_symbols")];
-    char stringpool_str4431[sizeof ("getservbyname_r_proto")];
-    char stringpool_str4446[sizeof ("longdblsize")];
-    char stringpool_str4451[sizeof ("sitearchexp")];
-    char stringpool_str4452[sizeof ("api_revision")];
-    char stringpool_str4471[sizeof ("shortsize")];
-    char stringpool_str4472[sizeof ("d_gethbyaddr")];
-    char stringpool_str4476[sizeof ("sitehtml1direxp")];
-    char stringpool_str4478[sizeof ("make_set_make")];
-    char stringpool_str4489[sizeof ("usecbacktrace")];
-    char stringpool_str4500[sizeof ("d_fchown")];
-    char stringpool_str4508[sizeof ("d_getpgrp2")];
-    char stringpool_str4509[sizeof ("voidflags")];
-    char stringpool_str4533[sizeof ("ctime_r_proto")];
-    char stringpool_str4543[sizeof ("archobjs")];
-    char stringpool_str4545[sizeof ("ccwarnflags")];
-    char stringpool_str4556[sizeof ("libdb_needs_pthread")];
-    char stringpool_str4560[sizeof ("ldlibpthname")];
-    char stringpool_str4565[sizeof ("malloc_cflags")];
-    char stringpool_str4579[sizeof ("d_remquo")];
-    char stringpool_str4598[sizeof ("d_perl_otherlibdirs")];
-    char stringpool_str4601[sizeof ("d_setservent_r")];
-    char stringpool_str4604[sizeof ("d_endservent_r")];
-    char stringpool_str4613[sizeof ("d_gethostbyaddr_r")];
-    char stringpool_str4615[sizeof ("extensions")];
-    char stringpool_str4616[sizeof ("installvendorhtml3dir")];
-    char stringpool_str4634[sizeof ("d_pwpasswd")];
-    char stringpool_str4635[sizeof ("d_ldexpl")];
-    char stringpool_str4643[sizeof ("d_writev")];
-    char stringpool_str4650[sizeof ("installvendorhtml1dir")];
-    char stringpool_str4674[sizeof ("installsitehtml3dir")];
-    char stringpool_str4691[sizeof ("perl_revision")];
-    char stringpool_str4703[sizeof ("d_attribut")];
-    char stringpool_str4707[sizeof ("d_madvise")];
-    char stringpool_str4708[sizeof ("installsitehtml1dir")];
-    char stringpool_str4710[sizeof ("vendorlib_stem")];
-    char stringpool_str4715[sizeof ("d_gethostent_r")];
-    char stringpool_str4749[sizeof ("usekernprocpathname")];
-    char stringpool_str4750[sizeof ("d_getpwnam_r")];
-    char stringpool_str4761[sizeof ("d_getgrgid_r")];
-    char stringpool_str4764[sizeof ("getpwent_r_proto")];
-    char stringpool_str4782[sizeof ("shsharp")];
-    char stringpool_str4786[sizeof ("installhtmlhelpdir")];
-    char stringpool_str4787[sizeof ("d_ldbl_dig")];
-    char stringpool_str4827[sizeof ("patchlevel")];
-    char stringpool_str4835[sizeof ("useversionedarchname")];
-    char stringpool_str4853[sizeof ("d_flexfnam")];
-    char stringpool_str4873[sizeof ("vendorbinexp")];
-    char stringpool_str4879[sizeof ("inc_version_list")];
-    char stringpool_str4881[sizeof ("use64bitint")];
-    char stringpool_str4886[sizeof ("vendorlibexp")];
-    char stringpool_str4893[sizeof ("inc_version_list_init")];
-    char stringpool_str4909[sizeof ("d_gdbmndbm_h_uses_prototypes")];
-    char stringpool_str4917[sizeof ("toke_cflags")];
-    char stringpool_str4942[sizeof ("useposix")];
-    char stringpool_str4950[sizeof ("d_scm_rights")];
-    char stringpool_str4958[sizeof ("quadkind")];
-    char stringpool_str4996[sizeof ("ignore_versioned_solibs")];
-    char stringpool_str5017[sizeof ("d__fwalk")];
-    char stringpool_str5027[sizeof ("getservbyport_r_proto")];
-    char stringpool_str5035[sizeof ("d_gethbyname")];
-    char stringpool_str5038[sizeof ("git_uncommitted_changes")];
-    char stringpool_str5090[sizeof ("sig_num_init")];
-    char stringpool_str5096[sizeof ("vendorman3direxp")];
-    char stringpool_str5103[sizeof ("gethostbyaddr_r_proto")];
-    char stringpool_str5119[sizeof ("db_version_major")];
-    char stringpool_str5121[sizeof ("d_bsdgetpgrp")];
-    char stringpool_str5130[sizeof ("vendorman1direxp")];
-    char stringpool_str5133[sizeof ("dtraceobject")];
-    char stringpool_str5135[sizeof ("firstmakefile")];
-    char stringpool_str5143[sizeof ("d_frexpl")];
-    char stringpool_str5144[sizeof ("perl_version")];
-    char stringpool_str5171[sizeof ("d_stdio_ptr_lval")];
-    char stringpool_str5184[sizeof ("d_vendorarch")];
-    char stringpool_str5186[sizeof ("d_stdio_ptr_lval_sets_cnt")];
-    char stringpool_str5187[sizeof ("groupstype")];
-    char stringpool_str5191[sizeof ("d_stdio_ptr_lval_nochange_cnt")];
-    char stringpool_str5197[sizeof ("exe_ext")];
-    char stringpool_str5206[sizeof ("lseeksize")];
-    char stringpool_str5218[sizeof ("ccflags_uselargefiles")];
-    char stringpool_str5227[sizeof ("d_wcsxfrm")];
-    char stringpool_str5229[sizeof ("d_gdbm_ndbm_h_uses_prototypes")];
-    char stringpool_str5242[sizeof ("d_void_closedir")];
-    char stringpool_str5252[sizeof ("i_execinfo")];
-    char stringpool_str5278[sizeof ("d_killpg")];
-    char stringpool_str5284[sizeof ("ldflags_uselargefiles")];
-    char stringpool_str5287[sizeof ("usequadmath")];
-    char stringpool_str5303[sizeof ("d_mkstemp")];
-    char stringpool_str5305[sizeof ("d_mkstemps")];
-    char stringpool_str5307[sizeof ("d_mkdtemp")];
-    char stringpool_str5318[sizeof ("d_getservbyport_r")];
-    char stringpool_str5319[sizeof ("hash_func")];
-    char stringpool_str5333[sizeof ("gccosandvers")];
-    char stringpool_str5354[sizeof ("d_sockaddr_sa_len")];
-    char stringpool_str5386[sizeof ("socksizetype")];
-    char stringpool_str5389[sizeof ("getlogin_r_proto")];
-    char stringpool_str5407[sizeof ("d_sbrkproto")];
-    char stringpool_str5409[sizeof ("d_qgcvt")];
-    char stringpool_str5418[sizeof ("usemultiplicity")];
-    char stringpool_str5426[sizeof ("d_getservent_r")];
-    char stringpool_str5457[sizeof ("usevfork")];
-    char stringpool_str5467[sizeof ("h_sysfile")];
-    char stringpool_str5474[sizeof ("d_charvspr")];
-    char stringpool_str5485[sizeof ("siteprefix")];
-    char stringpool_str5491[sizeof ("d_usleepproto")];
-    char stringpool_str5498[sizeof ("d_pwquota")];
-    char stringpool_str5507[sizeof ("siteprefixexp")];
-    char stringpool_str5517[sizeof ("gccansipedantic")];
-    char stringpool_str5524[sizeof ("crypt_r_proto")];
-    char stringpool_str5531[sizeof ("bootstrap_charset")];
-    char stringpool_str5533[sizeof ("d_pwchange")];
-    char stringpool_str5539[sizeof ("getpwnam_r_proto")];
-    char stringpool_str5550[sizeof ("vendorprefix")];
-    char stringpool_str5593[sizeof ("i_sysfilio")];
-    char stringpool_str5600[sizeof ("obj_ext")];
-    char stringpool_str5616[sizeof ("d_attribute_deprecated")];
-    char stringpool_str5692[sizeof ("d_ipv6_mreq")];
-    char stringpool_str5710[sizeof ("vendorhtml3direxp")];
-    char stringpool_str5715[sizeof ("d_getnetprotos")];
-    char stringpool_str5729[sizeof ("quadtype")];
-    char stringpool_str5744[sizeof ("vendorhtml1direxp")];
-    char stringpool_str5752[sizeof ("doublenanbytes")];
-    char stringpool_str5781[sizeof ("d_nv_preserves_uv")];
-    char stringpool_str5823[sizeof ("BuiltWithPatchPerl")];
-    char stringpool_str5864[sizeof ("d_attribute_malloc")];
-    char stringpool_str5912[sizeof ("i_systimek")];
-    char stringpool_str5915[sizeof ("d_attribute_unused")];
-    char stringpool_str5919[sizeof ("d_attribute_pure")];
-    char stringpool_str5921[sizeof ("d_msg_peek")];
-    char stringpool_str5937[sizeof ("d_attribute_format")];
-    char stringpool_str5944[sizeof ("git_unpushed")];
-    char stringpool_str5957[sizeof ("getgrgid_r_proto")];
-    char stringpool_str5967[sizeof ("d_attribute_warn_unused_result")];
-    char stringpool_str5972[sizeof ("nonxs_ext")];
-    char stringpool_str5976[sizeof ("d_builtin_arith_overflow")];
-    char stringpool_str6020[sizeof ("d_getpwuid_r")];
-    char stringpool_str6077[sizeof ("getprotobynumber_r_proto")];
-    char stringpool_str6106[sizeof ("uvxformat")];
-    char stringpool_str6118[sizeof ("longdblkind")];
-    char stringpool_str6126[sizeof ("d_attribute_noreturn")];
-    char stringpool_str6185[sizeof ("d_attribute_nonnull")];
-    char stringpool_str6228[sizeof ("d_getsbyport")];
-    char stringpool_str6254[sizeof ("d_libm_lib_version")];
-    char stringpool_str6258[sizeof ("usensgetexecutablepath")];
-    char stringpool_str6277[sizeof ("d_nexttoward")];
-    char stringpool_str6280[sizeof ("otherlibdirs")];
-    char stringpool_str6320[sizeof ("d_nv_zero_is_allbits_zero")];
-    char stringpool_str6369[sizeof ("d_sockpair")];
-    char stringpool_str6372[sizeof ("gnulibc_version")];
-    char stringpool_str6506[sizeof ("d_pthread_atfork")];
-    char stringpool_str6520[sizeof ("useshrplib")];
-    char stringpool_str6526[sizeof ("usevendorprefix")];
-    char stringpool_str6532[sizeof ("html3direxp")];
-    char stringpool_str6566[sizeof ("html1direxp")];
-    char stringpool_str6580[sizeof ("d_pwexpire")];
-    char stringpool_str6664[sizeof ("i_sysstatvfs")];
-    char stringpool_str6696[sizeof ("libswanted_nolargefiles")];
-    char stringpool_str6736[sizeof ("d_msg_proxy")];
-    char stringpool_str6799[sizeof ("config_heavy")];
-    char stringpool_str6809[sizeof ("getpwuid_r_proto")];
-    char stringpool_str6820[sizeof ("d_ndbm_h_uses_prototypes")];
-    char stringpool_str6877[sizeof ("vendorscriptexp")];
-    char stringpool_str6888[sizeof ("d_gethostbyname_r")];
-    char stringpool_str6989[sizeof ("libswanted_uselargefiles")];
-    char stringpool_str7114[sizeof ("d_ipv6_mreq_source")];
-    char stringpool_str7130[sizeof ("api_versionstring")];
-    char stringpool_str7282[sizeof ("perl_subversion")];
-    char stringpool_str7391[sizeof ("version_patchlevel_string")];
-    char stringpool_str7453[sizeof ("d_libname_unique")];
-    char stringpool_str7538[sizeof ("d_modfl_pow32_bug")];
-    char stringpool_str7599[sizeof ("d_getservbyname_r")];
-    char stringpool_str7969[sizeof ("doubleinfbytes")];
-    char stringpool_str8038[sizeof ("vendorprefixexp")];
-    char stringpool_str8122[sizeof ("prefixexp")];
-    char stringpool_str8519[sizeof ("dl_so_eq_ext")];
-    char stringpool_str9553[sizeof ("nv_preserves_uv_bits")];
-    char stringpool_str10035[sizeof ("known_extensions")];
-    char stringpool_str10184[sizeof ("nv_overflows_integers_at")];
+    char stringpool_str1769[sizeof ("archlib")];
+    char stringpool_str1772[sizeof ("gidsign")];
+    char stringpool_str1774[sizeof ("i_sysaccess")];
+    char stringpool_str1779[sizeof ("d_getgrent")];
+    char stringpool_str1783[sizeof ("sSCNfldbl")];
+    char stringpool_str1784[sizeof ("sPRIfldbl")];
+    char stringpool_str1788[sizeof ("d_siginfo_si_addr")];
+    char stringpool_str1790[sizeof ("libsfiles")];
+    char stringpool_str1803[sizeof ("d_getsent")];
+    char stringpool_str1804[sizeof ("d_getnent")];
+    char stringpool_str1807[sizeof ("aphostname")];
+    char stringpool_str1815[sizeof ("i16type")];
+    char stringpool_str1817[sizeof ("i64type")];
+    char stringpool_str1821[sizeof ("d_chroot")];
+    char stringpool_str1833[sizeof ("PERL_API_VERSION")];
+    char stringpool_str1836[sizeof ("i_crypt")];
+    char stringpool_str1837[sizeof ("d_crypt")];
+    char stringpool_str1838[sizeof ("PERL_API_REVISION")];
+    char stringpool_str1840[sizeof ("d_getfsstat")];
+    char stringpool_str1841[sizeof ("PERL_API_SUBVERSION")];
+    char stringpool_str1842[sizeof ("d_crypt_r")];
+    char stringpool_str1844[sizeof ("i32type")];
+    char stringpool_str1848[sizeof ("d_statvfs")];
+    char stringpool_str1854[sizeof ("usereentrant")];
+    char stringpool_str1859[sizeof ("i_bsdioctl")];
+    char stringpool_str1863[sizeof ("d_siginfo_si_errno")];
+    char stringpool_str1865[sizeof ("d_stdio_stream_array")];
+    char stringpool_str1869[sizeof ("d_archlib")];
+    char stringpool_str1871[sizeof ("usefaststdio")];
+    char stringpool_str1875[sizeof ("d_getgrps")];
+    char stringpool_str1877[sizeof ("i_sysioctl")];
+    char stringpool_str1881[sizeof ("d_locconv")];
+    char stringpool_str1891[sizeof ("d_wcstombs")];
+    char stringpool_str1898[sizeof ("found_libucb")];
+    char stringpool_str1903[sizeof ("siteman3direxp")];
+    char stringpool_str1908[sizeof ("siteman1direxp")];
+    char stringpool_str1913[sizeof ("d_siginfo_si_pid")];
+    char stringpool_str1914[sizeof ("d_uselocale")];
+    char stringpool_str1915[sizeof ("Author")];
+    char stringpool_str1917[sizeof ("i_sysmount")];
+    char stringpool_str1920[sizeof ("sitehtml3dir")];
+    char stringpool_str1927[sizeof ("sitehtml1dir")];
+    char stringpool_str1929[sizeof ("d_mymalloc")];
+    char stringpool_str1933[sizeof ("d_j0")];
+    char stringpool_str1937[sizeof ("i_sysmode")];
+    char stringpool_str1941[sizeof ("gidformat")];
+    char stringpool_str1942[sizeof ("d_setsid")];
+    char stringpool_str1948[sizeof ("i_sysstat")];
+    char stringpool_str1955[sizeof ("d_munmap")];
+    char stringpool_str1956[sizeof ("d_fd_macros")];
+    char stringpool_str1957[sizeof ("d_fpclass")];
+    char stringpool_str1958[sizeof ("d_setresgid")];
+    char stringpool_str1961[sizeof ("d_msg_ctrunc")];
+    char stringpool_str1963[sizeof ("d_shmdt")];
+    char stringpool_str1966[sizeof ("sizesize")];
+    char stringpool_str1969[sizeof ("pidtype")];
+    char stringpool_str1977[sizeof ("d_isascii")];
+    char stringpool_str1980[sizeof ("vi")];
+    char stringpool_str1986[sizeof ("d_getpent")];
+    char stringpool_str1989[sizeof ("d_shmat")];
+    char stringpool_str1992[sizeof ("d_j0l")];
+    char stringpool_str1995[sizeof ("d_tzname")];
+    char stringpool_str2004[sizeof ("d_seteuid")];
+    char stringpool_str2007[sizeof ("i8size")];
+    char stringpool_str2016[sizeof ("d_fpclassl")];
+    char stringpool_str2022[sizeof ("touch")];
+    char stringpool_str2024[sizeof ("d_logb")];
+    char stringpool_str2028[sizeof ("d_setruid")];
+    char stringpool_str2031[sizeof ("d_hasmntopt")];
+    char stringpool_str2034[sizeof ("i_gdbm")];
+    char stringpool_str2045[sizeof ("d_dbminitproto")];
+    char stringpool_str2054[sizeof ("old_pthread_create_joinable")];
+    char stringpool_str2056[sizeof ("hostcat")];
+    char stringpool_str2060[sizeof ("userelocatableinc")];
+    char stringpool_str2061[sizeof ("d_u32align")];
+    char stringpool_str2078[sizeof ("installusrbinperl")];
+    char stringpool_str2080[sizeof ("ld_can_script")];
+    char stringpool_str2090[sizeof ("cppsymbols")];
+    char stringpool_str2092[sizeof ("sPRIgldbl")];
+    char stringpool_str2095[sizeof ("osvers")];
+    char stringpool_str2100[sizeof ("d_duplocale")];
+    char stringpool_str2107[sizeof ("i_libutil")];
+    char stringpool_str2113[sizeof ("zcat")];
+    char stringpool_str2121[sizeof ("d_setnetent_r")];
+    char stringpool_str2124[sizeof ("d_endnetent_r")];
+    char stringpool_str2125[sizeof ("mv")];
+    char stringpool_str2128[sizeof ("glibpth")];
+    char stringpool_str2131[sizeof ("zip")];
+    char stringpool_str2147[sizeof ("d_longlong")];
+    char stringpool_str2148[sizeof ("i_syslog")];
+    char stringpool_str2150[sizeof ("d_siginfo_si_uid")];
+    char stringpool_str2151[sizeof ("d_casti32")];
+    char stringpool_str2152[sizeof ("d_shmctl")];
+    char stringpool_str2159[sizeof ("i_pthread")];
+    char stringpool_str2162[sizeof ("usedtrace")];
+    char stringpool_str2166[sizeof ("stdio_ptr")];
+    char stringpool_str2171[sizeof ("sendmail")];
+    char stringpool_str2173[sizeof ("d_remainder")];
+    char stringpool_str2180[sizeof ("d_longdbl")];
+    char stringpool_str2181[sizeof ("Revision")];
+    char stringpool_str2182[sizeof ("d_siginfo_si_status")];
+    char stringpool_str2184[sizeof ("version")];
+    char stringpool_str2187[sizeof ("installsitebin")];
+    char stringpool_str2194[sizeof ("i_termio")];
+    char stringpool_str2196[sizeof ("h_fcntl")];
+    char stringpool_str2198[sizeof ("i_termios")];
+    char stringpool_str2199[sizeof ("d_builtin_expect")];
+    char stringpool_str2204[sizeof ("d_getgrent_r")];
+    char stringpool_str2205[sizeof ("revision")];
+    char stringpool_str2206[sizeof ("uidtype")];
+    char stringpool_str2207[sizeof ("rd_nodata")];
+    char stringpool_str2209[sizeof ("d_isblank")];
+    char stringpool_str2211[sizeof ("usemallocwrap")];
+    char stringpool_str2215[sizeof ("setservent_r_proto")];
+    char stringpool_str2217[sizeof ("sitescript")];
+    char stringpool_str2218[sizeof ("endservent_r_proto")];
+    char stringpool_str2221[sizeof ("d_llround")];
+    char stringpool_str2222[sizeof ("byteorder")];
+    char stringpool_str2226[sizeof ("sitescriptexp")];
+    char stringpool_str2229[sizeof ("d_sysconf")];
+    char stringpool_str2231[sizeof ("pthread_h_first")];
+    char stringpool_str2232[sizeof ("u16type")];
+    char stringpool_str2233[sizeof ("d_strlcpy")];
+    char stringpool_str2234[sizeof ("u64type")];
+    char stringpool_str2237[sizeof ("d_random_r")];
+    char stringpool_str2240[sizeof ("setnetent_r_proto")];
+    char stringpool_str2243[sizeof ("endnetent_r_proto")];
+    char stringpool_str2246[sizeof ("d_sqrtl")];
+    char stringpool_str2249[sizeof ("d_siginfo_si_fd")];
+    char stringpool_str2258[sizeof ("d_tm_tm_gmtoff")];
+    char stringpool_str2261[sizeof ("u32type")];
+    char stringpool_str2270[sizeof ("d_inetpton")];
+    char stringpool_str2275[sizeof ("d_freelocale")];
+    char stringpool_str2280[sizeof ("d_llroundl")];
+    char stringpool_str2282[sizeof ("targetsh")];
+    char stringpool_str2285[sizeof ("d_strtoq")];
+    char stringpool_str2287[sizeof ("perlpath")];
+    char stringpool_str2288[sizeof ("d_stdiobase")];
+    char stringpool_str2299[sizeof ("installhtml3dir")];
+    char stringpool_str2304[sizeof ("d_semop")];
+    char stringpool_str2305[sizeof ("d_clearenv")];
+    char stringpool_str2307[sizeof ("spitshell")];
+    char stringpool_str2308[sizeof ("d_pathconf")];
+    char stringpool_str2309[sizeof ("strerror_r_proto")];
+    char stringpool_str2311[sizeof ("path_sep")];
+    char stringpool_str2313[sizeof ("vendorman3dir")];
+    char stringpool_str2318[sizeof ("vendorman1dir")];
+    char stringpool_str2322[sizeof ("d_sresuproto")];
+    char stringpool_str2326[sizeof ("installhtml1dir")];
+    char stringpool_str2327[sizeof ("vendorbin")];
+    char stringpool_str2331[sizeof ("d_getprotoprotos")];
+    char stringpool_str2332[sizeof ("installman3dir")];
+    char stringpool_str2337[sizeof ("installman1dir")];
+    char stringpool_str2341[sizeof ("myuname")];
+    char stringpool_str2343[sizeof ("d_sethent")];
+    char stringpool_str2346[sizeof ("d_endhent")];
+    char stringpool_str2347[sizeof ("d_tcsetpgrp")];
+    char stringpool_str2348[sizeof ("d_gethname")];
+    char stringpool_str2352[sizeof ("d_vendorbin")];
+    char stringpool_str2359[sizeof ("d_msgget")];
+    char stringpool_str2366[sizeof ("_exe")];
+    char stringpool_str2368[sizeof ("ccstdflags")];
+    char stringpool_str2369[sizeof ("d_pwcomment")];
+    char stringpool_str2370[sizeof ("baserev")];
+    char stringpool_str2377[sizeof ("sPRIx64")];
+    char stringpool_str2386[sizeof ("d_fchmod")];
+    char stringpool_str2387[sizeof ("sitebinexp")];
+    char stringpool_str2389[sizeof ("d_dir_dd_fd")];
+    char stringpool_str2391[sizeof ("vendorlib")];
+    char stringpool_str2392[sizeof ("privlib")];
+    char stringpool_str2394[sizeof ("d_pwgecos")];
+    char stringpool_str2395[sizeof ("usethreads")];
+    char stringpool_str2398[sizeof ("byacc")];
+    char stringpool_str2406[sizeof ("perl_static_inline")];
+    char stringpool_str2412[sizeof ("i_gdbmndbm")];
+    char stringpool_str2417[sizeof ("d_getpgid")];
+    char stringpool_str2424[sizeof ("u8size")];
+    char stringpool_str2425[sizeof ("extras")];
+    char stringpool_str2429[sizeof ("dlext")];
+    char stringpool_str2430[sizeof ("sGMTIME_max")];
+    char stringpool_str2433[sizeof ("installsiteman3dir")];
+    char stringpool_str2434[sizeof ("d_PRIx64")];
+    char stringpool_str2437[sizeof ("cppstdin")];
+    char stringpool_str2438[sizeof ("installsiteman1dir")];
+    char stringpool_str2439[sizeof ("d_vendorscript")];
+    char stringpool_str2440[sizeof ("d_malloc_size")];
+    char stringpool_str2444[sizeof ("bash")];
+    char stringpool_str2447[sizeof ("d_dosuid")];
+    char stringpool_str2452[sizeof ("d_syscall")];
+    char stringpool_str2453[sizeof ("d_stdstdio")];
+    char stringpool_str2466[sizeof ("d_sitearch")];
+    char stringpool_str2469[sizeof ("eunicefix")];
+    char stringpool_str2475[sizeof ("d_old_pthread_create_joinable")];
+    char stringpool_str2476[sizeof ("i_sysstatfs")];
+    char stringpool_str2483[sizeof ("ttyname_r_proto")];
+    char stringpool_str2484[sizeof ("uniq")];
+    char stringpool_str2486[sizeof ("intsize")];
+    char stringpool_str2488[sizeof ("locincpth")];
+    char stringpool_str2494[sizeof ("vaproto")];
+    char stringpool_str2495[sizeof ("d_dbl_dig")];
+    char stringpool_str2499[sizeof ("cppflags")];
+    char stringpool_str2507[sizeof ("d_fpclassify")];
+    char stringpool_str2515[sizeof ("i_fenv")];
+    char stringpool_str2516[sizeof ("i16size")];
+    char stringpool_str2518[sizeof ("i64size")];
+    char stringpool_str2523[sizeof ("d_quad")];
+    char stringpool_str2533[sizeof ("d_setlocale_r")];
+    char stringpool_str2536[sizeof ("d_portable")];
+    char stringpool_str2541[sizeof ("d_wctomb")];
+    char stringpool_str2545[sizeof ("i32size")];
+    char stringpool_str2556[sizeof ("chgrp")];
+    char stringpool_str2557[sizeof ("cccdlflags")];
+    char stringpool_str2558[sizeof ("stdio_filbuf")];
+    char stringpool_str2559[sizeof ("d_setresuid")];
+    char stringpool_str2560[sizeof ("d_nl_langinfo")];
+    char stringpool_str2567[sizeof ("d_re_comp")];
+    char stringpool_str2570[sizeof ("sLOCALTIME_max")];
+    char stringpool_str2572[sizeof ("expr")];
+    char stringpool_str2579[sizeof ("d_getnameinfo")];
+    char stringpool_str2583[sizeof ("full_csh")];
+    char stringpool_str2589[sizeof ("lddlflags")];
+    char stringpool_str2594[sizeof ("d_exp2")];
+    char stringpool_str2600[sizeof ("d_localtime64")];
+    char stringpool_str2603[sizeof ("mailx")];
+    char stringpool_str2610[sizeof ("selectminbits")];
+    char stringpool_str2613[sizeof ("netdb_host_type")];
+    char stringpool_str2618[sizeof ("gidtype")];
+    char stringpool_str2620[sizeof ("d_getnetbyname_r")];
+    char stringpool_str2627[sizeof ("d_fs_data_s")];
+    char stringpool_str2633[sizeof ("castflags")];
+    char stringpool_str2638[sizeof ("netdb_name_type")];
+    char stringpool_str2641[sizeof ("cppminus")];
+    char stringpool_str2653[sizeof ("d_setpwent")];
+    char stringpool_str2656[sizeof ("d_endpwent")];
+    char stringpool_str2661[sizeof ("d_mbstowcs")];
+    char stringpool_str2663[sizeof ("libpth")];
+    char stringpool_str2670[sizeof ("d_fpos64_t")];
+    char stringpool_str2678[sizeof ("i_inttypes")];
+    char stringpool_str2679[sizeof ("madlyh")];
+    char stringpool_str2681[sizeof ("i_vfork")];
+    char stringpool_str2682[sizeof ("d_vfork")];
+    char stringpool_str2687[sizeof ("d_statfs_s")];
+    char stringpool_str2688[sizeof ("d_fsetpos")];
+    char stringpool_str2690[sizeof ("ptrsize")];
+    char stringpool_str2691[sizeof ("setprotoent_r_proto")];
+    char stringpool_str2694[sizeof ("endprotoent_r_proto")];
+    char stringpool_str2698[sizeof ("d_pwclass")];
+    char stringpool_str2700[sizeof ("targetenv")];
+    char stringpool_str2730[sizeof ("groupcat")];
+    char stringpool_str2731[sizeof ("scriptdirexp")];
+    char stringpool_str2732[sizeof ("nvmantbits")];
+    char stringpool_str2733[sizeof ("i_arpainet")];
+    char stringpool_str2737[sizeof ("signal_t")];
+    char stringpool_str2741[sizeof ("d_volatile")];
+    char stringpool_str2744[sizeof ("d_expm1")];
+    char stringpool_str2751[sizeof ("sig_name_init")];
+    char stringpool_str2759[sizeof ("cf_by")];
+    char stringpool_str2760[sizeof ("d_newlocale")];
+    char stringpool_str2766[sizeof ("ccsymbols")];
+    char stringpool_str2767[sizeof ("d_closedir")];
+    char stringpool_str2773[sizeof ("d_semctl_semun")];
+    char stringpool_str2778[sizeof ("d_syscallproto")];
+    char stringpool_str2787[sizeof ("d_semctl_semid_ds")];
+    char stringpool_str2793[sizeof ("i_sgtty")];
+    char stringpool_str2794[sizeof ("d_siginfo_si_band")];
+    char stringpool_str2796[sizeof ("ccdlflags")];
+    char stringpool_str2797[sizeof ("d_vsnprintf")];
+    char stringpool_str2798[sizeof ("myhostname")];
+    char stringpool_str2800[sizeof ("sethostent_r_proto")];
+    char stringpool_str2803[sizeof ("endhostent_r_proto")];
+    char stringpool_str2805[sizeof ("d_asctime_r")];
+    char stringpool_str2814[sizeof ("d_asctime64")];
+    char stringpool_str2819[sizeof ("d_seekdir")];
+    char stringpool_str2820[sizeof ("d_ttyname_r")];
+    char stringpool_str2825[sizeof ("cf_email")];
+    char stringpool_str2833[sizeof ("d_gmtime_r")];
+    char stringpool_str2835[sizeof ("doublemantbits")];
+    char stringpool_str2853[sizeof ("d_pwage")];
+    char stringpool_str2859[sizeof ("useithreads")];
+    char stringpool_str2860[sizeof ("d_copysign")];
+    char stringpool_str2861[sizeof ("shrpenv")];
+    char stringpool_str2866[sizeof ("chown")];
+    char stringpool_str2868[sizeof ("d_link")];
+    char stringpool_str2869[sizeof ("op_cflags")];
+    char stringpool_str2874[sizeof ("i_shadow")];
+    char stringpool_str2887[sizeof ("d_setprotoent_r")];
+    char stringpool_str2889[sizeof ("d_c99_variadic_macros")];
+    char stringpool_str2890[sizeof ("d_endprotoent_r")];
+    char stringpool_str2897[sizeof ("d_sigaction")];
+    char stringpool_str2899[sizeof ("d_shmget")];
+    char stringpool_str2901[sizeof ("myarchname")];
+    char stringpool_str2902[sizeof ("d_getprotobyname_r")];
+    char stringpool_str2907[sizeof ("uidsize")];
+    char stringpool_str2914[sizeof ("i_varargs")];
+    char stringpool_str2915[sizeof ("d_setreuid")];
+    char stringpool_str2918[sizeof ("d_getpbynumber")];
+    char stringpool_str2919[sizeof ("d_copysignl")];
+    char stringpool_str2922[sizeof ("installarchlib")];
+    char stringpool_str2924[sizeof ("fflushNULL")];
+    char stringpool_str2925[sizeof ("d_unsetenv")];
+    char stringpool_str2933[sizeof ("u16size")];
+    char stringpool_str2935[sizeof ("u64size")];
+    char stringpool_str2942[sizeof ("git_remote_branch")];
+    char stringpool_str2944[sizeof ("d_lgamma_r")];
+    char stringpool_str2945[sizeof ("flex")];
+    char stringpool_str2950[sizeof ("i_rpcsvcdbm")];
+    char stringpool_str2953[sizeof ("d_getnetent_r")];
+    char stringpool_str2958[sizeof ("d_chown")];
+    char stringpool_str2962[sizeof ("u32size")];
+    char stringpool_str2964[sizeof ("d_mkdir")];
+    char stringpool_str2965[sizeof ("gzip")];
+    char stringpool_str2966[sizeof ("d_mktime")];
+    char stringpool_str2970[sizeof ("setgrent_r_proto")];
+    char stringpool_str2973[sizeof ("endgrent_r_proto")];
+    char stringpool_str2977[sizeof ("make")];
+    char stringpool_str2980[sizeof ("mkdir")];
+    char stringpool_str2987[sizeof ("ansi2knr")];
+    char stringpool_str2993[sizeof ("man3ext")];
+    char stringpool_str2996[sizeof ("usedevel")];
+    char stringpool_str2998[sizeof ("man1ext")];
+    char stringpool_str3000[sizeof ("d_getservprotos")];
+    char stringpool_str3001[sizeof ("mips_type")];
+    char stringpool_str3003[sizeof ("d_msgrcv")];
+    char stringpool_str3012[sizeof ("installvendorman3dir")];
+    char stringpool_str3013[sizeof ("d_oldpthreads")];
+    char stringpool_str3015[sizeof ("archlibexp")];
+    char stringpool_str3017[sizeof ("installvendorman1dir")];
+    char stringpool_str3019[sizeof ("i_sysdir")];
+    char stringpool_str3020[sizeof ("d_sprintf_returns_strlen")];
+    char stringpool_str3023[sizeof ("libswanted")];
+    char stringpool_str3024[sizeof ("i_values")];
+    char stringpool_str3026[sizeof ("d_mktime64")];
+    char stringpool_str3028[sizeof ("i_socks")];
+    char stringpool_str3031[sizeof ("i_stdlib")];
+    char stringpool_str3034[sizeof ("charbits")];
+    char stringpool_str3036[sizeof ("sockethdr")];
+    char stringpool_str3039[sizeof ("defvoidused")];
+    char stringpool_str3044[sizeof ("prototype")];
+    char stringpool_str3046[sizeof ("static_ext")];
+    char stringpool_str3047[sizeof ("getservent_r_proto")];
+    char stringpool_str3048[sizeof ("Locker")];
+    char stringpool_str3050[sizeof ("targetport")];
+    char stringpool_str3059[sizeof ("vendorhtml3dir")];
+    char stringpool_str3064[sizeof ("vendorhtml1dir")];
+    char stringpool_str3072[sizeof ("getnetent_r_proto")];
+    char stringpool_str3073[sizeof ("d_log1p")];
+    char stringpool_str3074[sizeof ("d_fmax")];
+    char stringpool_str3076[sizeof ("getprotobyname_r_proto")];
+    char stringpool_str3077[sizeof ("nveformat")];
+    char stringpool_str3078[sizeof ("d_setpwent_r")];
+    char stringpool_str3081[sizeof ("d_endpwent_r")];
+    char stringpool_str3082[sizeof ("ivdformat")];
+    char stringpool_str3093[sizeof ("d_snprintf")];
+    char stringpool_str3097[sizeof ("d_getppid")];
+    char stringpool_str3103[sizeof ("prefix")];
+    char stringpool_str3107[sizeof ("netdb_hlen_type")];
+    char stringpool_str3110[sizeof ("d_readlink")];
+    char stringpool_str3115[sizeof ("libspath")];
+    char stringpool_str3122[sizeof ("installhtmldir")];
+    char stringpool_str3125[sizeof ("d_vprintf")];
+    char stringpool_str3129[sizeof ("d_union_semun")];
+    char stringpool_str3134[sizeof ("d_hypot")];
+    char stringpool_str3141[sizeof ("d_setservent_r")];
+    char stringpool_str3144[sizeof ("d_endservent_r")];
+    char stringpool_str3148[sizeof ("d_memmove")];
+    char stringpool_str3149[sizeof ("installvendorscript")];
+    char stringpool_str3160[sizeof ("orderlib")];
+    char stringpool_str3161[sizeof ("d_gethostprotos")];
+    char stringpool_str3162[sizeof ("pmake")];
+    char stringpool_str3170[sizeof ("installstyle")];
+    char stringpool_str3175[sizeof ("d_gethent")];
+    char stringpool_str3179[sizeof ("d_tcgetpgrp")];
+    char stringpool_str3181[sizeof ("setlocale_r_proto")];
+    char stringpool_str3190[sizeof ("ldflags_nolargefiles")];
+    char stringpool_str3191[sizeof ("d_nearbyint")];
+    char stringpool_str3201[sizeof ("d_bzero")];
+    char stringpool_str3204[sizeof ("git_commit_id")];
+    char stringpool_str3210[sizeof ("installbin")];
+    char stringpool_str3228[sizeof ("nvtype")];
+    char stringpool_str3230[sizeof ("ivtype")];
+    char stringpool_str3252[sizeof ("usemymalloc")];
+    char stringpool_str3254[sizeof ("issymlink")];
+    char stringpool_str3256[sizeof ("d_symlink")];
+    char stringpool_str3263[sizeof ("d_strxfrm")];
+    char stringpool_str3267[sizeof ("doop_cflags")];
+    char stringpool_str3268[sizeof ("d_fegetround")];
+    char stringpool_str3270[sizeof ("d_phostname")];
+    char stringpool_str3271[sizeof ("d_socklen_t")];
+    char stringpool_str3280[sizeof ("git_commit_id_title")];
+    char stringpool_str3281[sizeof ("timetype")];
+    char stringpool_str3287[sizeof ("d_sigprocmask")];
+    char stringpool_str3300[sizeof ("d_getgrnam_r")];
+    char stringpool_str3302[sizeof ("d_sethostent_r")];
+    char stringpool_str3303[sizeof ("installsitelib")];
+    char stringpool_str3305[sizeof ("d_endhostent_r")];
+    char stringpool_str3308[sizeof ("gccversion")];
+    char stringpool_str3314[sizeof ("socketlib")];
+    char stringpool_str3319[sizeof ("gidsize")];
+    char stringpool_str3327[sizeof ("d_setregid")];
+    char stringpool_str3328[sizeof ("need_va_copy")];
+    char stringpool_str3330[sizeof ("d_stdio_cnt_lval")];
+    char stringpool_str3346[sizeof ("d_pthread_yield")];
+    char stringpool_str3347[sizeof ("targetarch")];
+    char stringpool_str3349[sizeof ("d_getcwd")];
+    char stringpool_str3362[sizeof ("d_tmpnam_r")];
+    char stringpool_str3364[sizeof ("modetype")];
+    char stringpool_str3366[sizeof ("phostname")];
+    char stringpool_str3377[sizeof ("longdblmantbits")];
+    char stringpool_str3378[sizeof ("api_subversion")];
+    char stringpool_str3379[sizeof ("d_waitpid")];
+    char stringpool_str3385[sizeof ("d_setvbuf")];
+    char stringpool_str3393[sizeof ("d_bcopy")];
+    char stringpool_str3397[sizeof ("ccflags_nolargefiles")];
+    char stringpool_str3398[sizeof ("d_regcomp")];
+    char stringpool_str3399[sizeof ("d_vendorlib")];
+    char stringpool_str3401[sizeof ("mydomain")];
+    char stringpool_str3412[sizeof ("git_describe")];
+    char stringpool_str3435[sizeof ("d_xenix")];
+    char stringpool_str3440[sizeof ("d_fork")];
+    char stringpool_str3443[sizeof ("madlyobj")];
+    char stringpool_str3444[sizeof ("loclibpth")];
+    char stringpool_str3446[sizeof ("i_varhdr")];
+    char stringpool_str3450[sizeof ("d_fpgetround")];
+    char stringpool_str3456[sizeof ("d_grpasswd")];
+    char stringpool_str3464[sizeof ("d_voidsig")];
+    char stringpool_str3466[sizeof ("sig_count")];
+    char stringpool_str3473[sizeof ("versiononly")];
+    char stringpool_str3485[sizeof ("d_getpwent")];
+    char stringpool_str3488[sizeof ("d_sin6_scope_id")];
+    char stringpool_str3494[sizeof ("i_sysuio")];
+    char stringpool_str3501[sizeof ("d_getnetbyaddr_r")];
+    char stringpool_str3504[sizeof ("i_sysparam")];
+    char stringpool_str3507[sizeof ("d_pthread_attr_setscope")];
+    char stringpool_str3514[sizeof ("d_ptrdiff_t")];
+    char stringpool_str3517[sizeof ("d_getnbyaddr")];
+    char stringpool_str3520[sizeof ("d_fgetpos")];
+    char stringpool_str3523[sizeof ("getprotoent_r_proto")];
+    char stringpool_str3529[sizeof ("d_recvmsg")];
+    char stringpool_str3538[sizeof ("d_gettimeod")];
+    char stringpool_str3540[sizeof ("d_shmatprototype")];
+    char stringpool_str3545[sizeof ("installprivlib")];
+    char stringpool_str3552[sizeof ("db_version_minor")];
+    char stringpool_str3555[sizeof ("d_socket")];
+    char stringpool_str3558[sizeof ("i_sysutsname")];
+    char stringpool_str3560[sizeof ("d_memcpy")];
+    char stringpool_str3561[sizeof ("setpwent_r_proto")];
+    char stringpool_str3562[sizeof ("html3dir")];
+    char stringpool_str3564[sizeof ("endpwent_r_proto")];
+    char stringpool_str3566[sizeof ("d_sched_yield")];
+    char stringpool_str3567[sizeof ("html1dir")];
+    char stringpool_str3576[sizeof ("installprefixexp")];
+    char stringpool_str3579[sizeof ("uvoformat")];
+    char stringpool_str3582[sizeof ("d_localtime_r")];
+    char stringpool_str3589[sizeof ("binexp")];
+    char stringpool_str3600[sizeof ("nvfformat")];
+    char stringpool_str3607[sizeof ("d_localtime_r_needs_tzset")];
+    char stringpool_str3619[sizeof ("d_getespwnam")];
+    char stringpool_str3632[sizeof ("gethostent_r_proto")];
+    char stringpool_str3636[sizeof ("mmaptype")];
+    char stringpool_str3638[sizeof ("privlibexp")];
+    char stringpool_str3644[sizeof ("randseedtype")];
+    char stringpool_str3647[sizeof ("uvtype")];
+    char stringpool_str3651[sizeof ("xlibpth")];
+    char stringpool_str3658[sizeof ("d_setpgrp")];
+    char stringpool_str3662[sizeof ("subversion")];
+    char stringpool_str3666[sizeof ("i_systime")];
+    char stringpool_str3668[sizeof ("i_systimes")];
+    char stringpool_str3676[sizeof ("api_revision")];
+    char stringpool_str3678[sizeof ("freetype")];
+    char stringpool_str3685[sizeof ("uselongdouble")];
+    char stringpool_str3688[sizeof ("d_getsbyname")];
+    char stringpool_str3689[sizeof ("d_getnbyname")];
+    char stringpool_str3695[sizeof ("libsfound")];
+    char stringpool_str3697[sizeof ("installsitearch")];
+    char stringpool_str3698[sizeof ("d_setpgrp2")];
+    char stringpool_str3699[sizeof ("vendorscript")];
+    char stringpool_str3719[sizeof ("d_getprotoent_r")];
+    char stringpool_str3728[sizeof ("i_systypes")];
+    char stringpool_str3734[sizeof ("targetmkdir")];
+    char stringpool_str3741[sizeof ("ctime_r_proto")];
+    char stringpool_str3744[sizeof ("selecttype")];
+    char stringpool_str3775[sizeof ("i_langinfo")];
+    char stringpool_str3778[sizeof ("d_mbtowc")];
+    char stringpool_str3786[sizeof ("nvEUformat")];
+    char stringpool_str3788[sizeof ("nvGUformat")];
+    char stringpool_str3793[sizeof ("nvFUformat")];
+    char stringpool_str3799[sizeof ("d_getprpwnam")];
+    char stringpool_str3800[sizeof ("i_syswait")];
+    char stringpool_str3802[sizeof ("getgrent_r_proto")];
+    char stringpool_str3804[sizeof ("hostgenerate")];
+    char stringpool_str3806[sizeof ("d_fstatvfs")];
+    char stringpool_str3811[sizeof ("gmake")];
+    char stringpool_str3813[sizeof ("d_writev")];
+    char stringpool_str3814[sizeof ("vendorlib_stem")];
+    char stringpool_str3821[sizeof ("yaccflags")];
+    char stringpool_str3823[sizeof ("d_safemcpy")];
+    char stringpool_str3836[sizeof ("regexec_cflags")];
+    char stringpool_str3837[sizeof ("installvendorbin")];
+    char stringpool_str3846[sizeof ("getnetbyaddr_r_proto")];
+    char stringpool_str3847[sizeof ("d_getlogin")];
+    char stringpool_str3848[sizeof ("d_strctcpy")];
+    char stringpool_str3850[sizeof ("cpp_stuff")];
+    char stringpool_str3852[sizeof ("longdblinfbytes")];
+    char stringpool_str3871[sizeof ("d_getpbyname")];
+    char stringpool_str3881[sizeof ("i_sysvfs")];
+    char stringpool_str3885[sizeof ("lib_ext")];
+    char stringpool_str3893[sizeof ("installvendorlib")];
+    char stringpool_str3897[sizeof ("ieeefp_h")];
+    char stringpool_str3908[sizeof ("nvgformat")];
+    char stringpool_str3910[sizeof ("d_getpwent_r")];
+    char stringpool_str3915[sizeof ("uvuformat")];
+    char stringpool_str3916[sizeof ("d_lockf")];
+    char stringpool_str3918[sizeof ("fpostype")];
+    char stringpool_str3929[sizeof ("nvsize")];
+    char stringpool_str3931[sizeof ("ivsize")];
+    char stringpool_str3956[sizeof ("d_safebcpy")];
+    char stringpool_str3973[sizeof ("d_getservent_r")];
+    char stringpool_str3985[sizeof ("d_setlinebuf")];
+    char stringpool_str3986[sizeof ("git_commit_date")];
+    char stringpool_str3994[sizeof ("d_fchdir")];
+    char stringpool_str4001[sizeof ("procselfexe")];
+    char stringpool_str4002[sizeof ("d_static_inline")];
+    char stringpool_str4018[sizeof ("getnetbyname_r_proto")];
+    char stringpool_str4024[sizeof ("d_lchown")];
+    char stringpool_str4047[sizeof ("d_pwpasswd")];
+    char stringpool_str4059[sizeof ("malloctype")];
+    char stringpool_str4061[sizeof ("sched_yield")];
+    char stringpool_str4088[sizeof ("d_statfs_f_flags")];
+    char stringpool_str4091[sizeof ("awk")];
+    char stringpool_str4095[sizeof ("d_getspnam")];
+    char stringpool_str4097[sizeof ("i_sysfile")];
+    char stringpool_str4130[sizeof ("d_sockatmark")];
+    char stringpool_str4134[sizeof ("d_gethostent_r")];
+    char stringpool_str4147[sizeof ("direntrytype")];
+    char stringpool_str4150[sizeof ("dynamic_ext")];
+    char stringpool_str4154[sizeof ("fflushall")];
+    char stringpool_str4166[sizeof ("d_sockaddr_in6")];
+    char stringpool_str4168[sizeof ("ksh")];
+    char stringpool_str4174[sizeof ("usemorebits")];
+    char stringpool_str4192[sizeof ("d_vms_case_sensitive_symbols")];
+    char stringpool_str4195[sizeof ("uselargefiles")];
+    char stringpool_str4197[sizeof ("extern_C")];
+    char stringpool_str4199[sizeof ("d_msghdr_s")];
+    char stringpool_str4206[sizeof ("uvXUformat")];
+    char stringpool_str4208[sizeof ("d_siginfo_si_value")];
+    char stringpool_str4212[sizeof ("api_version")];
+    char stringpool_str4218[sizeof ("shmattype")];
+    char stringpool_str4222[sizeof ("db_prefixtype")];
+    char stringpool_str4224[sizeof ("getspnam_r_proto")];
+    char stringpool_str4238[sizeof ("localtime_r_proto")];
+    char stringpool_str4251[sizeof ("o_nonblock")];
+    char stringpool_str4253[sizeof ("random_r_proto")];
+    char stringpool_str4258[sizeof ("config_args")];
+    char stringpool_str4260[sizeof ("config_arg5")];
+    char stringpool_str4262[sizeof ("config_arg6")];
+    char stringpool_str4264[sizeof ("config_arg0")];
+    char stringpool_str4267[sizeof ("i_xlocale")];
+    char stringpool_str4272[sizeof ("d_getlogin_r")];
+    char stringpool_str4277[sizeof ("longdblnanbytes")];
+    char stringpool_str4282[sizeof ("config_arg3")];
+    char stringpool_str4283[sizeof ("config_arg7")];
+    char stringpool_str4285[sizeof ("d_gnulibc")];
+    char stringpool_str4286[sizeof ("config_arg32")];
+    char stringpool_str4287[sizeof ("config_arg1")];
+    char stringpool_str4288[sizeof ("config_arg33")];
+    char stringpool_str4289[sizeof ("config_arg4")];
+    char stringpool_str4291[sizeof ("config_arg12")];
+    char stringpool_str4293[sizeof ("config_arg13")];
+    char stringpool_str4296[sizeof ("config_arg2")];
+    char stringpool_str4298[sizeof ("config_arg39")];
+    char stringpool_str4300[sizeof ("config_arg22")];
+    char stringpool_str4302[sizeof ("config_arg23")];
+    char stringpool_str4303[sizeof ("config_arg19")];
+    char stringpool_str4304[sizeof ("d_remquo")];
+    char stringpool_str4306[sizeof ("lkflags")];
+    char stringpool_str4307[sizeof ("config_arg8")];
+    char stringpool_str4308[sizeof ("config_arg30")];
+    char stringpool_str4309[sizeof ("config_arg34")];
+    char stringpool_str4310[sizeof ("config_arg9")];
+    char stringpool_str4312[sizeof ("config_arg29")];
+    char stringpool_str4313[sizeof ("config_arg10")];
+    char stringpool_str4314[sizeof ("config_arg14")];
+    char stringpool_str4315[sizeof ("config_arg31")];
+    char stringpool_str4316[sizeof ("git_uncommitted_changes")];
+    char stringpool_str4320[sizeof ("config_arg11")];
+    char stringpool_str4321[sizeof ("config_arg38")];
+    char stringpool_str4322[sizeof ("config_arg20")];
+    char stringpool_str4323[sizeof ("config_arg24")];
+    char stringpool_str4325[sizeof ("config_arg37")];
+    char stringpool_str4326[sizeof ("config_arg18")];
+    char stringpool_str4327[sizeof ("d_getprotobynumber_r")];
+    char stringpool_str4328[sizeof ("git_branch")];
+    char stringpool_str4329[sizeof ("config_arg21")];
+    char stringpool_str4330[sizeof ("config_arg17")];
+    char stringpool_str4333[sizeof ("config_arg35")];
+    char stringpool_str4334[sizeof ("d_sockatmarkproto")];
+    char stringpool_str4335[sizeof ("config_arg28")];
+    char stringpool_str4336[sizeof ("config_arg36")];
+    char stringpool_str4338[sizeof ("config_arg15")];
+    char stringpool_str4339[sizeof ("config_arg27")];
+    char stringpool_str4341[sizeof ("config_arg16")];
+    char stringpool_str4347[sizeof ("config_arg25")];
+    char stringpool_str4348[sizeof ("uvsize")];
+    char stringpool_str4350[sizeof ("config_arg26")];
+    char stringpool_str4353[sizeof ("i_quadmath")];
+    char stringpool_str4362[sizeof ("installvendorarch")];
+    char stringpool_str4366[sizeof ("ccwarnflags")];
+    char stringpool_str4367[sizeof ("ccversion")];
+    char stringpool_str4377[sizeof ("installsitescript")];
+    char stringpool_str4378[sizeof ("perl_patchlevel")];
+    char stringpool_str4390[sizeof ("d_nextafter")];
+    char stringpool_str4392[sizeof ("config_argc")];
+    char stringpool_str4393[sizeof ("getpwent_r_proto")];
+    char stringpool_str4402[sizeof ("d_mkfifo")];
+    char stringpool_str4409[sizeof ("installvendorhtml3dir")];
+    char stringpool_str4414[sizeof ("installvendorhtml1dir")];
+    char stringpool_str4421[sizeof ("cryptlib")];
+    char stringpool_str4442[sizeof ("alignbytes")];
+    char stringpool_str4448[sizeof ("d_voidtty")];
+    char stringpool_str4462[sizeof ("extensions")];
+    char stringpool_str4463[sizeof ("sitehtml3direxp")];
+    char stringpool_str4466[sizeof ("sig_num_init")];
+    char stringpool_str4470[sizeof ("sitehtml1direxp")];
+    char stringpool_str4473[sizeof ("tmpnam_r_proto")];
+    char stringpool_str4476[sizeof ("d_printf_format_null")];
+    char stringpool_str4490[sizeof ("d_getpgrp")];
+    char stringpool_str4491[sizeof ("d_fchown")];
+    char stringpool_str4502[sizeof ("d_bsdsetpgrp")];
+    char stringpool_str4509[sizeof ("d_sigsetjmp")];
+    char stringpool_str4520[sizeof ("d_getspnam_r")];
+    char stringpool_str4521[sizeof ("sitearchexp")];
+    char stringpool_str4530[sizeof ("d_getpgrp2")];
+    char stringpool_str4531[sizeof ("voidflags")];
+    char stringpool_str4535[sizeof ("mallocobj")];
+    char stringpool_str4537[sizeof ("package")];
+    char stringpool_str4543[sizeof ("vendorarch")];
+    char stringpool_str4547[sizeof ("d_ldexpl")];
+    char stringpool_str4552[sizeof ("vendorarchexp")];
+    char stringpool_str4556[sizeof ("spackage")];
+    char stringpool_str4576[sizeof ("use64bitall")];
+    char stringpool_str4590[sizeof ("gccosandvers")];
+    char stringpool_str4591[sizeof ("db_hashtype")];
+    char stringpool_str4609[sizeof ("ssizetype")];
+    char stringpool_str4616[sizeof ("d_madvise")];
+    char stringpool_str4635[sizeof ("d_wcsxfrm")];
+    char stringpool_str4641[sizeof ("d_usleepproto")];
+    char stringpool_str4656[sizeof ("st_ino_sign")];
+    char stringpool_str4689[sizeof ("vendorbinexp")];
+    char stringpool_str4693[sizeof ("libs_nolargefiles")];
+    char stringpool_str4698[sizeof ("d_builtin_prefetch")];
+    char stringpool_str4753[sizeof ("vendorlibexp")];
+    char stringpool_str4756[sizeof ("perl_revision")];
+    char stringpool_str4767[sizeof ("db_version_patch")];
+    char stringpool_str4779[sizeof ("d__fwalk")];
+    char stringpool_str4788[sizeof ("ldlibpthname")];
+    char stringpool_str4820[sizeof ("d_getnetprotos")];
+    char stringpool_str4830[sizeof ("d_getservbyport_r")];
+    char stringpool_str4850[sizeof ("d_getpagsz")];
+    char stringpool_str4853[sizeof ("crypt_r_proto")];
+    char stringpool_str4858[sizeof ("vendorman3direxp")];
+    char stringpool_str4863[sizeof ("vendorman1direxp")];
+    char stringpool_str4865[sizeof ("shsharp")];
+    char stringpool_str4867[sizeof ("d_getgrgid_r")];
+    char stringpool_str4876[sizeof ("patchlevel")];
+    char stringpool_str4888[sizeof ("d_gethbyaddr")];
+    char stringpool_str4898[sizeof ("getgrnam_r_proto")];
+    char stringpool_str4899[sizeof ("d_socks5_init")];
+    char stringpool_str4904[sizeof ("canned_gperf")];
+    char stringpool_str4923[sizeof ("d_fcntl_can_lock")];
+    char stringpool_str4928[sizeof ("d_charvspr")];
+    char stringpool_str4954[sizeof ("perl_version")];
+    char stringpool_str4973[sizeof ("useposix")];
+    char stringpool_str4977[sizeof ("d_flexfnam")];
+    char stringpool_str4988[sizeof ("ldflags_uselargefiles")];
+    char stringpool_str4997[sizeof ("d_gethostbyaddr_r")];
+    char stringpool_str5006[sizeof ("d_getpwnam_r")];
+    char stringpool_str5007[sizeof ("d_attribut")];
+    char stringpool_str5024[sizeof ("i_gdbm_ndbm")];
+    char stringpool_str5034[sizeof ("d_scm_rights")];
+    char stringpool_str5035[sizeof ("d_frexpl")];
+    char stringpool_str5041[sizeof ("useversionedarchname")];
+    char stringpool_str5058[sizeof ("usesitecustomize")];
+    char stringpool_str5060[sizeof ("d_gethbyname")];
+    char stringpool_str5069[sizeof ("sharpbang")];
+    char stringpool_str5070[sizeof ("sizetype")];
+    char stringpool_str5076[sizeof ("d_builtin_choose_expr")];
+    char stringpool_str5093[sizeof ("groupstype")];
+    char stringpool_str5095[sizeof ("gmtime_r_proto")];
+    char stringpool_str5127[sizeof ("cppccsymbols")];
+    char stringpool_str5148[sizeof ("exe_ext")];
+    char stringpool_str5162[sizeof ("d_pwquota")];
+    char stringpool_str5180[sizeof ("doublenanbytes")];
+    char stringpool_str5182[sizeof ("inc_version_list")];
+    char stringpool_str5190[sizeof ("BuiltWithPatchPerl")];
+    char stringpool_str5192[sizeof ("usemultiplicity")];
+    char stringpool_str5193[sizeof ("inc_version_list_init")];
+    char stringpool_str5195[sizeof ("ccflags_uselargefiles")];
+    char stringpool_str5220[sizeof ("installsitehtml3dir")];
+    char stringpool_str5225[sizeof ("installsitehtml1dir")];
+    char stringpool_str5243[sizeof ("vendorprefix")];
+    char stringpool_str5246[sizeof ("libdb_needs_pthread")];
+    char stringpool_str5295[sizeof ("hash_func")];
+    char stringpool_str5298[sizeof ("malloc_cflags")];
+    char stringpool_str5311[sizeof ("usekernprocpathname")];
+    char stringpool_str5330[sizeof ("d_malloc_good_size")];
+    char stringpool_str5334[sizeof ("d_bsdgetpgrp")];
+    char stringpool_str5335[sizeof ("installhtmlhelpdir")];
+    char stringpool_str5345[sizeof ("use64bitint")];
+    char stringpool_str5346[sizeof ("i_execinfo")];
+    char stringpool_str5368[sizeof ("ignore_versioned_solibs")];
+    char stringpool_str5371[sizeof ("longlongsize")];
+    char stringpool_str5387[sizeof ("d_pwchange")];
+    char stringpool_str5402[sizeof ("d_stdio_ptr_lval")];
+    char stringpool_str5403[sizeof ("quadkind")];
+    char stringpool_str5414[sizeof ("d_stdio_ptr_lval_sets_cnt")];
+    char stringpool_str5419[sizeof ("d_stdio_ptr_lval_nochange_cnt")];
+    char stringpool_str5430[sizeof ("d_qgcvt")];
+    char stringpool_str5437[sizeof ("usecbacktrace")];
+    char stringpool_str5465[sizeof ("db_version_major")];
+    char stringpool_str5466[sizeof ("h_sysfile")];
+    char stringpool_str5469[sizeof ("d_perl_otherlibdirs")];
+    char stringpool_str5480[sizeof ("d_getsbyport")];
+    char stringpool_str5485[sizeof ("archobjs")];
+    char stringpool_str5489[sizeof ("getpwnam_r_proto")];
+    char stringpool_str5496[sizeof ("make_set_make")];
+    char stringpool_str5502[sizeof ("usequadmath")];
+    char stringpool_str5515[sizeof ("lseektype")];
+    char stringpool_str5551[sizeof ("siteprefix")];
+    char stringpool_str5560[sizeof ("siteprefixexp")];
+    char stringpool_str5573[sizeof ("i_sysfilio")];
+    char stringpool_str5586[sizeof ("getservbyname_r_proto")];
+    char stringpool_str5592[sizeof ("uquadtype")];
+    char stringpool_str5604[sizeof ("vendorhtml3direxp")];
+    char stringpool_str5609[sizeof ("vendorhtml1direxp")];
+    char stringpool_str5627[sizeof ("dtraceobject")];
+    char stringpool_str5629[sizeof ("d_backtrace")];
+    char stringpool_str5633[sizeof ("quadtype")];
+    char stringpool_str5651[sizeof ("d_gdbmndbm_h_uses_prototypes")];
+    char stringpool_str5660[sizeof ("d_void_closedir")];
+    char stringpool_str5675[sizeof ("d_nv_preserves_uv")];
+    char stringpool_str5686[sizeof ("firstmakefile")];
+    char stringpool_str5687[sizeof ("d_mkstemp")];
+    char stringpool_str5689[sizeof ("d_mkstemps")];
+    char stringpool_str5691[sizeof ("d_mkdtemp")];
+    char stringpool_str5723[sizeof ("d_ldbl_dig")];
+    char stringpool_str5730[sizeof ("gnulibc_version")];
+    char stringpool_str5746[sizeof ("getlogin_r_proto")];
+    char stringpool_str5759[sizeof ("nonxs_ext")];
+    char stringpool_str5763[sizeof ("st_ino_size")];
+    char stringpool_str5789[sizeof ("toke_cflags")];
+    char stringpool_str5808[sizeof ("usevfork")];
+    char stringpool_str5812[sizeof ("d_killpg")];
+    char stringpool_str5823[sizeof ("obj_ext")];
+    char stringpool_str5850[sizeof ("uvxformat")];
+    char stringpool_str5865[sizeof ("clocktype")];
+    char stringpool_str5878[sizeof ("shortsize")];
+    char stringpool_str5885[sizeof ("d_pwexpire")];
+    char stringpool_str5950[sizeof ("d_builtin_arith_overflow")];
+    char stringpool_str5962[sizeof ("git_unpushed")];
+    char stringpool_str6004[sizeof ("gccansipedantic")];
+    char stringpool_str6036[sizeof ("longdblsize")];
+    char stringpool_str6041[sizeof ("libswanted_nolargefiles")];
+    char stringpool_str6059[sizeof ("getservbyport_r_proto")];
+    char stringpool_str6070[sizeof ("socksizetype")];
+    char stringpool_str6134[sizeof ("d_nexttoward")];
+    char stringpool_str6144[sizeof ("d_sockaddr_sa_len")];
+    char stringpool_str6161[sizeof ("d_getpwuid_r")];
+    char stringpool_str6171[sizeof ("gethostbyname_r_proto")];
+    char stringpool_str6187[sizeof ("d_ipv6_mreq")];
+    char stringpool_str6199[sizeof ("d_vendorarch")];
+    char stringpool_str6222[sizeof ("d_sbrkproto")];
+    char stringpool_str6242[sizeof ("vendorscriptexp")];
+    char stringpool_str6274[sizeof ("bootstrap_charset")];
+    char stringpool_str6304[sizeof ("getprotobynumber_r_proto")];
+    char stringpool_str6345[sizeof ("libswanted_uselargefiles")];
+    char stringpool_str6346[sizeof ("d_attribute_format")];
+    char stringpool_str6347[sizeof ("usensgetexecutablepath")];
+    char stringpool_str6368[sizeof ("d_pthread_atfork")];
+    char stringpool_str6373[sizeof ("d_msg_peek")];
+    char stringpool_str6405[sizeof ("d_attribute_deprecated")];
+    char stringpool_str6419[sizeof ("d_attribute_malloc")];
+    char stringpool_str6424[sizeof ("i_sysstatvfs")];
+    char stringpool_str6448[sizeof ("usevendorprefix")];
+    char stringpool_str6458[sizeof ("i_systimek")];
+    char stringpool_str6465[sizeof ("getgrgid_r_proto")];
+    char stringpool_str6483[sizeof ("d_attribute_unused")];
+    char stringpool_str6499[sizeof ("d_attribute_pure")];
+    char stringpool_str6505[sizeof ("d_gdbm_ndbm_h_uses_prototypes")];
+    char stringpool_str6515[sizeof ("otherlibdirs")];
+    char stringpool_str6546[sizeof ("d_attribute_warn_unused_result")];
+    char stringpool_str6591[sizeof ("d_attribute_noreturn")];
+    char stringpool_str6621[sizeof ("d_attribute_nonnull")];
+    char stringpool_str6630[sizeof ("html3direxp")];
+    char stringpool_str6635[sizeof ("html1direxp")];
+    char stringpool_str6639[sizeof ("d_modfl_pow32_bug")];
+    char stringpool_str6644[sizeof ("getpwuid_r_proto")];
+    char stringpool_str6652[sizeof ("perl_subversion")];
+    char stringpool_str6679[sizeof ("d_msg_proxy")];
+    char stringpool_str6823[sizeof ("gethostbyaddr_r_proto")];
+    char stringpool_str6891[sizeof ("longdblkind")];
+    char stringpool_str6895[sizeof ("useshrplib")];
+    char stringpool_str6910[sizeof ("version_patchlevel_string")];
+    char stringpool_str7004[sizeof ("d_getservbyname_r")];
+    char stringpool_str7054[sizeof ("d_sockpair")];
+    char stringpool_str7057[sizeof ("api_versionstring")];
+    char stringpool_str7165[sizeof ("d_gethostbyname_r")];
+    char stringpool_str7244[sizeof ("lseeksize")];
+    char stringpool_str7253[sizeof ("d_libm_lib_version")];
+    char stringpool_str7314[sizeof ("config_heavy")];
+    char stringpool_str7729[sizeof ("doubleinfbytes")];
+    char stringpool_str7783[sizeof ("d_libname_unique")];
+    char stringpool_str7786[sizeof ("vendorprefixexp")];
+    char stringpool_str7851[sizeof ("d_nv_zero_is_allbits_zero")];
+    char stringpool_str7898[sizeof ("d_ipv6_mreq_source")];
+    char stringpool_str8040[sizeof ("prefixexp")];
+    char stringpool_str8164[sizeof ("dl_so_eq_ext")];
+    char stringpool_str8284[sizeof ("d_ndbm_h_uses_prototypes")];
+    char stringpool_str8907[sizeof ("nv_overflows_integers_at")];
+    char stringpool_str9532[sizeof ("known_extensions")];
+    char stringpool_str9602[sizeof ("nv_preserves_uv_bits")];
   };
 static const struct stringpool_t stringpool_contents =
   {
     "n",
-    "c",
     "Id",
+    "ARCH",
     "tee",
     "sed",
     "test",
-    "ARCH",
-    "cc",
-    "Mcc",
-    "tr",
     "CONFIG",
-    "src",
     "i_niin",
-    "d_nice",
-    "i_netdb",
+    "sPRIi64",
+    "sPRId64",
+    "SUBVERSION",
+    "tr",
+    "d_PRIXU64",
     "_a",
-    "d_rint",
-    "sGMTIME_min",
+    "PERL_SUBVERSION",
+    "PERL_VERSION",
+    "PATCHLEVEL",
     "Date",
-    "cat",
+    "PERL_REVISION",
+    "PERL_PATCHLEVEL",
     "date",
     "State",
-    "ar",
     "d_nan",
-    "tar",
-    "SUBVERSION",
+    "d_rint",
+    "sGMTIME_min",
     "d_stat",
-    "d_ctermid",
     "i_assert",
-    "d_strerrm",
     "d_asinh",
-    "d_strchr",
-    "startsh",
-    "Header",
-    "PERL_REVISION",
-    "dtrace",
-    "d_access",
-    "PERL_VERSION",
-    "d_rename",
-    "PERL_SUBVERSION",
-    "PATCHLEVEL",
-    "d_ctermid_r",
-    "d_readdir",
+    "ar",
     "ls",
     "ln",
+    "tar",
     "lns",
     "ld",
     "less",
-    "d_atanh",
-    "sPRIi64",
-    "sPRId64",
     "line",
     "lint",
-    "d_PRIXU64",
-    "d_readdir_r",
-    "trnl",
-    "i_dld",
-    "sitelib",
-    "d_isless",
-    "d_select",
-    "dlsrc",
-    "PERL_PATCHLEVEL",
+    "Header",
     "sPRIXU64",
-    "tail",
-    "cp",
+    "startsh",
+    "d_strerrm",
+    "i_dld",
+    "d_rename",
     "d_PRIi64",
     "d_PRId64",
-    "pr",
-    "d_class",
-    "d_scalbn",
-    "d_srand48_r",
-    "d_drand48_r",
-    "d_dladdr",
-    "d_strtod",
-    "scriptdir",
-    "sLOCALTIME_min",
-    "incpath",
-    "d_alarm",
-    "d_sanemcmp",
-    "d_strerror",
-    "d_telldir",
-    "lp",
-    "sleep",
-    "lpr",
+    "d_isless",
+    "d_atanh",
+    "d_select",
+    "d_readdir",
     "so",
-    "perl",
-    "to",
     "_o",
-    "d_statblks",
-    "drand01",
-    "nm",
-    "sort",
-    "d_strtol",
-    "d_strtold",
-    "cpp",
-    "rm",
-    "sitelib_stem",
-    "d_sem",
+    "to",
+    "trnl",
+    "tail",
+    "sPRIo64",
     "i_stdint",
+    "d_readdir_r",
+    "sort",
+    "drand01",
+    "c",
+    "d_isnan",
+    "i_dirent",
+    "d_dladdr",
+    "d_telldir",
+    "nm",
+    "d_nice",
+    "i_netdb",
+    "d_alarm",
+    "d_PRIo64",
+    "d_sem",
+    "src",
     "i_time",
     "d_time",
-    "d_pipe",
+    "cat",
     "d_times",
-    "perl5",
-    "i_dirent",
+    "rm",
     "mad",
-    "d_isnan",
-    "d_rmdir",
-    "emacs",
-    "d_acosh",
-    "d_setprior",
-    "ccname",
-    "d_aintl",
-    "stdio_base",
-    "man3dir",
-    "sPRIo64",
-    "d_srandom_r",
-    "perllibs",
-    "man1dir",
-    "timeincl",
+    "d_ctermid",
+    "d_srand48_r",
     "d_dlerror",
-    "d_PRIo64",
-    "cpio",
+    "d_srandom_r",
+    "d_isnanl",
+    "d_drand48_r",
+    "d_rmdir",
+    "d_aintl",
+    "dtrace",
+    "d_strchr",
+    "pr",
+    "sitelib",
+    "sLOCALTIME_min",
+    "d_ctermid_r",
+    "i_neterrno",
+    "man3dir",
+    "man1dir",
+    "dlsrc",
+    "timeincl",
+    "d_strtod",
+    "d_class",
+    "lp",
     "mail",
     "smail",
-    "d_isnanl",
-    "sPRIGUldbl",
-    "sPRIEUldbl",
-    "rmail",
-    "i_prot",
-    "sPRIFUldbl",
-    "d_PRIeldbl",
-    "d_open3",
-    "d_scalbnl",
-    "d_prctl",
-    "installscript",
-    "d_ip_mreq",
     "d_llrint",
-    "d_ip_mreq_source",
-    "more",
-    "d_strtoll",
+    "sleep",
     "i_mntent",
-    "d_strcoll",
-    "i_neterrno",
-    "run",
-    "perladmin",
-    "d_inetntop",
+    "more",
+    "d_acosh",
+    "lpr",
+    "cc",
+    "rmail",
+    "perl",
     "osname",
+    "perl5",
+    "Mcc",
+    "stdio_base",
+    "d_strerror",
+    "d_strtol",
+    "d_strtold",
+    "installscript",
+    "d_statblks",
+    "i_prot",
+    "d_open3",
+    "cp",
+    "d_access",
+    "emacs",
+    "d_atoll",
+    "siteman3dir",
+    "siteman1dir",
     "contains",
-    "d_eunice",
-    "usrinc",
-    "d_cuserid",
-    "d_drand48proto",
-    "d_trunc",
-    "d_memchr",
+    "sPRIEUldbl",
+    "sPRIGUldbl",
+    "scriptdir",
+    "incpath",
+    "d_PRIeldbl",
+    "sPRIFUldbl",
+    "d_sanemcmp",
+    "d_scalbn",
+    "d_ip_mreq",
+    "d_pipe",
     "i_poll",
     "d_poll",
-    "d_setitimer",
-    "d_oldsock",
-    "ppmarch",
-    "siteman3dir",
-    "d_lseekproto",
-    "sPRIu64",
-    "d_int64_t",
-    "usedl",
-    "d_telldirproto",
-    "i_malloc",
-    "siteman1dir",
-    "d_atoll",
-    "nm_opt",
-    "d_lrint",
-    "i_locale",
-    "d_truncl",
-    "d_PRIu64",
-    "d_lstat",
-    "i8size",
-    "compress",
-    "optimize",
-    "d_memcmp",
-    "sizesize",
-    "zcat",
-    "d_strlcat",
-    "use5005threads",
-    "d_mmap",
-    "d_tzname",
-    "find",
-    "d_strtouq",
     "d_llrintl",
-    "d_erf",
-    "afs",
-    "passcat",
-    "d_strerror_r",
-    "d_erfc",
-    "d_lrintl",
-    "d_dirfd",
-    "mallocsrc",
-    "usecperl",
-    "comm",
-    "d_eaccess",
-    "zip",
-    "usenm",
-    "d_const",
-    "Source",
-    "stdio_cnt",
-    "d_round",
-    "runnm",
-    "i_netinettcp",
-    "cpprun",
-    "d_unordered",
-    "uname",
-    "d_dup2",
-    "i_fp",
-    "usesocks",
-    "i_limits",
-    "d_semctl",
-    "d_strlcpy",
-    "d_umask",
-    "cpplast",
-    "multiarch",
-    "bin",
+    "perladmin",
+    "cpio",
+    "sitelib_stem",
+    "d_setprior",
+    "nm_opt",
+    "d_lseekproto",
+    "d_strtoll",
+    "sPRIu64",
+    "optimize",
     "dlltool",
-    "i_db",
-    "d_bsd",
-    "d_strtoul",
-    "d_ualarm",
-    "bin_ELF",
+    "d_eunice",
+    "run",
+    "d_int64_t",
+    "ccname",
+    "d_telldirproto",
+    "d_trunc",
+    "i_locale",
+    "perllibs",
+    "d_memchr",
+    "d_setitimer",
+    "d_inetntop",
+    "usedl",
+    "d_drand48proto",
+    "d_PRIu64",
+    "use5005threads",
+    "cpp",
+    "d_prctl",
+    "comm",
+    "d_lrint",
+    "d_mmap",
+    "d_scalbnl",
+    "d_lstat",
+    "d_truncl",
+    "stdio_cnt",
+    "find",
+    "d_oldsock",
+    "i_netinet_ip",
+    "i_netinet_ip6",
+    "d_round",
+    "mallocsrc",
+    "afs",
+    "d_strlcat",
+    "d_unordered",
+    "d_erf",
+    "d_strcoll",
+    "d_dirfd",
+    "usenm",
+    "d_cuserid",
+    "d_ip_mreq_source",
+    "d_lrintl",
+    "compress",
+    "usrinc",
+    "runnm",
+    "i_netinet6_in6",
+    "uname",
     "i_sfio",
     "d_sfio",
-    "ebcdic",
-    "d_cbrt",
+    "i_malloc",
+    "d_memcmp",
+    "i_limits",
+    "d_const",
+    "d_dup2",
+    "d_umask",
+    "d_faststdio",
+    "i_netinettcp",
+    "Source",
+    "d_strtouq",
+    "initialinstalllocation",
+    "d_fseeko",
     "d_fmin",
+    "d_lround",
     "d_fdim",
+    "d_erfc",
+    "d_ualarm",
+    "d_strerror_r",
+    "usesocks",
+    "d_fma",
+    "i_fp",
+    "ppmarch",
+    "d_semctl",
+    "readdir_r_proto",
+    "from",
+    "d_strtoul",
+    "passcat",
+    "usecperl",
+    "fpossize",
+    "multiarch",
+    "i_dlfcn",
     "i_fcntl",
     "d_fcntl",
-    "readdir_r_proto",
     "d_ctime_r",
-    "d_fma",
-    "d_faststdio",
-    "i_mallocmalloc",
-    "tbl",
-    "PERL_CONFIG_SH",
-    "libs",
-    "d_isinf",
-    "libc",
-    "strings",
-    "libsdirs",
-    "d_strtoull",
-    "sig_size",
-    "srand48_r_proto",
+    "d_ftello",
     "d_ctime64",
-    "d_fseeko",
+    "d_memset",
+    "d_lroundl",
+    "d_eaccess",
+    "mistrustnm",
+    "d_isinf",
+    "sig_size",
+    "d_strtoull",
+    "srand48_r_proto",
+    "srandom_r_proto",
     "drand48_r_proto",
-    "d_readdir64_r",
-    "i_dlfcn",
-    "sig_name",
-    "initialinstalllocation",
-    "i_stdarg",
     "i_unistd",
-    "useperlio",
-    "targetdir",
-    "ranlib",
-    "eagain",
-    "d_SCNfldbl",
-    "d_getaddrinfo",
+    "d_dlopen",
+    "d_flock",
+    "strings",
+    "d_eofnblk",
+    "sig_name",
+    "i_stdarg",
     "i_ustat",
     "d_ustat",
-    "d_inetaton",
-    "fpossize",
-    "d_PRIfldbl",
-    "d_truncate",
-    "d_isinfl",
-    "pg",
-    "d_lround",
-    "d_flock",
-    "d_eofnblk",
-    "grep",
-    "egrep",
-    "i_fp_class",
-    "d_fp_class",
-    "i_ieeefp",
-    "i_grp",
-    "d_setgrps",
-    "d_PRIGUldbl",
-    "d_PRIEUldbl",
-    "startperl",
-    "d_PRIFUldbl",
-    "d_fp_classify",
-    "u8size",
-    "bison",
-    "d_regcmp",
-    "d_dlopen",
-    "pager",
-    "sitebin",
     "d_mprotect",
-    "i_dbm",
-    "i_ndbm",
-    "d_ndbm",
-    "from",
-    "ctermid_r_proto",
-    "srandom_r_proto",
-    "d_memset",
+    "d_SCNfldbl",
+    "d_PRIfldbl",
+    "d_getaddrinfo",
+    "eagain",
+    "targetdir",
+    "d_isinfl",
+    "Log",
+    "d_modfl",
+    "d_truncate",
+    "i_mallocmalloc",
+    "d_setgrent",
+    "d_endgrent",
+    "startperl",
+    "cpprun",
+    "i_string",
     "d_setsent",
     "d_setnent",
     "d_finite",
     "d_endsent",
     "d_endnent",
     "d_futimes",
-    "Log",
-    "d_fp_classl",
-    "d_fds_bits",
-    "d_strftime",
+    "useperlio",
+    "usecrosscompile",
     "d_msg",
-    "d_setgrent",
-    "d_setlocale",
-    "d_endgrent",
-    "i_string",
-    "plibpth",
-    "nm_so_opt",
-    "d_cmsghdr_s",
-    "d_ftello",
-    "d_getprior",
-    "sPRIeldbl",
-    "mistrustnm",
+    "longsize",
+    "d_strftime",
     "targethost",
+    "pg",
+    "cpplast",
+    "d_atolf",
+    "d_log2",
     "installprefix",
     "uuname",
-    "d_bcmp",
+    "ctermid_r_proto",
+    "nm_so_opt",
+    "i_ieeefp",
+    "d_setgrps",
+    "bin",
+    "i_fp_class",
+    "d_fp_class",
+    "grep",
+    "i_db",
+    "egrep",
+    "d_bsd",
+    "i_grp",
+    "bin_ELF",
+    "d_fp_classify",
+    "d_isfinite",
+    "d_tgamma",
+    "d_gmtime64",
+    "PERL_CONFIG_SH",
+    "d_fd_set",
+    "i_stddef",
+    "pager",
     "i_sysndir",
     "d_index",
-    "d_tgamma",
-    "intsize",
-    "usesfio",
-    "d_ilogb",
-    "yacc",
-    "longsize",
-    "d_setpent",
-    "d_endpent",
-    "d_gmtime64",
-    "i64size",
-    "d_atolf",
-    "d_lroundl",
-    "d_accessx",
-    "d_pause",
-    "d_procselfexe",
-    "usecrosscompile",
-    "d_PRIgldbl",
-    "i16size",
-    "i_stddef",
-    "d_fd_set",
-    "libperl",
-    "d_lgamma",
-    "full_ar",
-    "d_ilogbl",
-    "d_usleep",
-    "i8type",
-    "d_modfl",
-    "seedfunc",
-    "d_isfinite",
-    "i_utime",
-    "RCSfile",
-    "ptrsize",
-    "d_dirnamlen",
-    "i_inttypes",
-    "d_log2",
-    "d_finitel",
-    "randbits",
-    "i32size",
-    "d_uname",
     "d_msgsnd",
     "d_getmnt",
-    "randfunc",
-    "PERL_API_VERSION",
-    "PERL_API_REVISION",
-    "d_mblen",
-    "PERL_API_SUBVERSION",
-    "sig_num",
-    "d_flockproto",
-    "d_isnormal",
-    "d_signbit",
-    "sitelibexp",
-    "d_getitimer",
-    "i_sysin",
+    "tbl",
+    "libs",
+    "full_ar",
+    "d_fp_classl",
+    "d_fds_bits",
+    "i_utime",
+    "libsdirs",
+    "d_lgamma",
     "d_isfinitel",
-    "i_stdbool",
-    "d_suidsafe",
+    "d_finitel",
+    "RCSfile",
+    "d_ilogb",
+    "bison",
     "i_float",
-    "d_msync",
-    "sh",
-    "readdir64_r_proto",
-    "d_sysernlst",
-    "csh",
-    "hint",
-    "sysman",
-    "rm_try",
-    "d_syserrlst",
-    "d_csh",
-    "d_sendmsg",
-    "d_setegid",
-    "i_bfd",
-    "ld_can_script",
-    "d_fdclose",
-    "d_setrgid",
+    "d_procselfexe",
+    "d_memmem",
+    "sitebin",
+    "d_uname",
+    "usesfio",
+    "d_cmsghdr_s",
+    "d_setpent",
+    "d_endpent",
+    "i_sysin",
+    "ranlib",
+    "d_readdir64_r",
     "nroff",
     "troff",
-    "shar",
-    "d_chsize",
-    "stdchar",
-    "i_sgtty",
-    "d_msg_oob",
-    "d_ftime",
-    "cf_time",
-    "sitearch",
-    "d_cplusplus",
-    "d_prctl_set_name",
-    "charsize",
-    "i_bsdioctl",
-    "archname",
-    "submit",
-    "madlysrc",
-    "d_fpathconf",
-    "i_sunmath",
-    "d_bzero",
-    "netdb_net_type",
-    "useopcode",
-    "d_memmem",
+    "d_pause",
+    "d_PRIEUldbl",
+    "d_flockproto",
+    "d_PRIGUldbl",
     "afsroot",
-    "incpth",
-    "d_setpgid",
-    "archlib",
-    "userelocatableinc",
-    "gzip",
-    "man3direxp",
+    "seedfunc",
+    "d_PRIFUldbl",
+    "d_ilogbl",
+    "d_regcmp",
+    "i_dbm",
+    "d_PRIgldbl",
+    "i_ndbm",
+    "d_ndbm",
+    "d_usleep",
+    "d_cbrt",
+    "d_ftime",
+    "d_msync",
+    "d_modflproto",
+    "d_sysernlst",
+    "libc",
+    "randfunc",
+    "d_msg_dontroute",
+    "sysman",
+    "d_inetaton",
+    "d_getprior",
+    "d_syserrlst",
+    "sPRIeldbl",
+    "rm_try",
+    "sig_num",
+    "inews",
+    "i8type",
+    "d_getitimer",
+    "d_suidsafe",
+    "d_wait4",
+    "ebcdic",
+    "i_sysmman",
+    "d_mblen",
+    "d_readv",
+    "cf_time",
+    "d_isnormal",
     "uidsign",
-    "d_uselocale",
+    "readdir64_r_proto",
+    "yacc",
     "d_setgrent_r",
     "d_endgrent_r",
-    "archname64",
-    "stdio_bufsiz",
-    "i_syssockio",
-    "man1direxp",
-    "d_msg_dontroute",
-    "doublesize",
+    "sh",
+    "d_accessx",
+    "hint",
+    "d_dirnamlen",
+    "d_sendmsg",
+    "d_setegid",
+    "d_msg_oob",
     "git_ancestor",
-    "ccflags",
-    "echo",
-    "uidsize",
-    "i_sysmman",
-    "d_shm",
-    "d_fpclass",
-    "d_modflproto",
-    "mips_type",
-    "stdio_stream_array",
-    "d_msgctl",
-    "u64size",
-    "i_math",
-    "d_castneg",
-    "ldflags",
-    "d_duplocale",
-    "asctime_r_proto",
-    "u16size",
-    "d_random_r",
+    "d_signbit",
+    "d_setrgid",
+    "shar",
+    "d_rewinddir",
+    "madlysrc",
+    "d_fdclose",
+    "sitearch",
+    "i_memory",
+    "sitelibexp",
+    "libperl",
+    "i_pwd",
+    "man3direxp",
+    "man1direxp",
+    "i_stdbool",
+    "plibpth",
+    "d_setlocale",
     "d_difftime",
-    "i_syspoll",
-    "d_archlib",
-    "i_machcthr",
-    "d_bcopy",
-    "d_fpclassl",
+    "stdio_bufsiz",
+    "csh",
+    "stdio_stream_array",
+    "d_Gconvert",
+    "d_bcmp",
+    "ldflags",
+    "d_csh",
     "d_fstatfs",
     "d_semget",
-    "u8type",
-    "sSCNfldbl",
-    "libsfiles",
-    "i_crypt",
-    "d_crypt",
-    "sPRIfldbl",
-    "d_lc_monetary_2008",
-    "d_crypt_r",
-    "d_chroot",
-    "d_stdiobase",
-    "u32size",
-    "d_difftime64",
-    "d_fsync",
-    "d_sresgproto",
     "uidformat",
-    "i_syssecrt",
-    "i_sysresrc",
-    "d_isblank",
-    "hostperl",
-    "i_sysaccess",
-    "i_sysioctl",
+    "randbits",
+    "d_chsize",
+    "d_shm",
+    "d_inc_version_list",
+    "d_difftime64",
+    "i_syssockio",
+    "useopcode",
+    "stdchar",
+    "asctime_r_proto",
+    "i_math",
+    "d_cplusplus",
+    "i_bfd",
+    "d_setproctitle",
     "i_sysun",
-    "i_memory",
-    "d_malloc_size",
-    "full_sed",
-    "d_munmap",
-    "prototype",
-    "chmod",
-    "d_htonl",
-    "ssizetype",
-    "i_sysselct",
-    "doublekind",
-    "rd_nodata",
-    "d_stdio_stream_array",
-    "d_timegm",
-    "d_getgrps",
-    "d_fd_macros",
-    "glibpth",
-    "d_tm_tm_zone",
-    "d_pseudofork",
-    "usedtrace",
-    "strerror_r_proto",
-    "i64type",
-    "d_dlsymun",
-    "i_gdbm",
-    "d_setlocale_r",
-    "installusrbinperl",
-    "d_dir_dd_fd",
-    "i16type",
-    "d_getmntent",
-    "d_setsid",
     "d_off64_t",
+    "charsize",
+    "d_setpgid",
+    "netdb_net_type",
+    "echo",
+    "full_sed",
+    "d_fsync",
+    "archname",
+    "d_fpathconf",
+    "d_msgctl",
+    "submit",
+    "d_getmntent",
+    "d_htonl",
+    "doublesize",
+    "i_sunmath",
+    "d_lc_monetary_2008",
+    "d_tm_tm_zone",
+    "d_dlsymun",
+    "d_castneg",
+    "i_syspoll",
+    "d_pseudofork",
+    "i_sysselct",
+    "archname64",
+    "hostosname",
+    "sysroot",
+    "d_timegm",
+    "incpth",
+    "hostperl",
+    "d_sresgproto",
+    "u8type",
+    "ccflags",
+    "d_wcscmp",
+    "i_syssecrt",
+    "i_machcthr",
+    "d_prctl_set_name",
+    "d_system",
+    "chmod",
+    "i_sysresrc",
+    "doublekind",
+    "archlib",
+    "gidsign",
+    "i_sysaccess",
+    "d_getgrent",
+    "sSCNfldbl",
+    "sPRIfldbl",
+    "d_siginfo_si_addr",
+    "libsfiles",
     "d_getsent",
     "d_getnent",
-    "d_j0",
-    "old_pthread_create_joinable",
-    "gidsign",
-    "d_siginfo_si_addr",
-    "sitehtml3dir",
-    "d_isascii",
-    "d_logb",
-    "d_getgrent",
-    "found_libucb",
-    "d_getfsstat",
-    "d_system",
-    "pidtype",
-    "d_casti32",
-    "byacc",
     "aphostname",
-    "sPRIgldbl",
+    "i16type",
+    "i64type",
+    "d_chroot",
+    "PERL_API_VERSION",
+    "i_crypt",
+    "d_crypt",
+    "PERL_API_REVISION",
+    "d_getfsstat",
+    "PERL_API_SUBVERSION",
+    "d_crypt_r",
     "i32type",
+    "d_statvfs",
+    "usereentrant",
+    "i_bsdioctl",
+    "d_siginfo_si_errno",
+    "d_stdio_stream_array",
+    "d_archlib",
     "usefaststdio",
+    "d_getgrps",
+    "i_sysioctl",
+    "d_locconv",
+    "d_wcstombs",
+    "found_libucb",
     "siteman3direxp",
-    "i_libutil",
-    "d_j0l",
-    "sysroot",
+    "siteman1direxp",
     "d_siginfo_si_pid",
+    "d_uselocale",
+    "Author",
+    "i_sysmount",
+    "sitehtml3dir",
+    "sitehtml1dir",
+    "d_mymalloc",
+    "d_j0",
+    "i_sysmode",
+    "gidformat",
+    "d_setsid",
+    "i_sysstat",
+    "d_munmap",
+    "d_fd_macros",
+    "d_fpclass",
     "d_setresgid",
-    "gidsize",
+    "d_msg_ctrunc",
+    "d_shmdt",
+    "sizesize",
+    "pidtype",
+    "d_isascii",
+    "vi",
+    "d_getpent",
+    "d_shmat",
+    "d_j0l",
+    "d_tzname",
+    "d_seteuid",
+    "i8size",
+    "d_fpclassl",
+    "touch",
+    "d_logb",
+    "d_setruid",
+    "d_hasmntopt",
+    "i_gdbm",
+    "d_dbminitproto",
+    "old_pthread_create_joinable",
+    "hostcat",
+    "userelocatableinc",
+    "d_u32align",
+    "installusrbinperl",
+    "ld_can_script",
+    "cppsymbols",
+    "sPRIgldbl",
+    "osvers",
+    "d_duplocale",
+    "i_libutil",
+    "zcat",
     "d_setnetent_r",
     "d_endnetent_r",
-    "cppsymbols",
-    "d_getpent",
-    "siteman1direxp",
-    "d_builtin_expect",
-    "touch",
-    "d_mymalloc",
-    "perl_static_inline",
-    "hostosname",
-    "Author",
-    "d_dbminitproto",
-    "d_shmdt",
-    "sitehtml1dir",
-    "i_sysstat",
-    "inews",
-    "hostcat",
-    "i_sysmode",
-    "d_shmat",
-    "d_hasmntopt",
-    "d_tcsetpgrp",
-    "d_readv",
-    "d_sysconf",
-    "vi",
-    "d_siginfo_si_errno",
-    "i_sysmount",
-    "d_semctl_semun",
-    "cppstdin",
+    "mv",
+    "glibpth",
+    "zip",
+    "d_longlong",
+    "i_syslog",
+    "d_siginfo_si_uid",
+    "d_casti32",
     "d_shmctl",
     "i_pthread",
-    "d_wait4",
-    "d_semctl_semid_ds",
-    "d_msg_ctrunc",
-    "d_seteuid",
-    "d_statfs_s",
-    "byteorder",
-    "gidformat",
-    "d_portable",
-    "d_setruid",
-    "perlpath",
-    "d_sched_yield",
-    "d_longdbl",
-    "i_pwd",
-    "i_syslog",
-    "d_remainder",
-    "sitescript",
-    "bash",
-    "d_wcscmp",
-    "h_fcntl",
-    "d_fpclassify",
-    "d_sitearch",
-    "d_inc_version_list",
-    "sitescriptexp",
-    "d_fs_data_s",
-    "signal_t",
-    "sendmail",
-    "d_u32align",
-    "path_sep",
-    "sig_name_init",
-    "pthread_h_first",
-    "d_syscall",
-    "installsitebin",
-    "installman3dir",
-    "ccstdflags",
-    "Revision",
-    "d_fpos64_t",
-    "sitebinexp",
-    "revision",
-    "d_dbl_dig",
-    "installman1dir",
-    "targetsh",
-    "d_vendorbin",
-    "uidtype",
-    "d_Gconvert",
-    "d_seekdir",
-    "d_inetpton",
-    "d_strtoq",
-    "setnetent_r_proto",
-    "cppflags",
-    "endnetent_r_proto",
-    "u64type",
-    "d_rewinddir",
-    "d_fchmod",
-    "cccdlflags",
-    "i_gdbmndbm",
-    "d_siginfo_si_uid",
-    "mv",
-    "u16type",
-    "i_termio",
-    "privlib",
-    "i_termios",
-    "osvers",
-    "ccsymbols",
-    "d_nl_langinfo",
-    "d_gmtime_r",
-    "chgrp",
-    "libpth",
-    "d_getpgid",
-    "d_siginfo_si_status",
-    "castflags",
-    "d_link",
-    "d_vendorscript",
-    "spitshell",
-    "installsiteman3dir",
+    "usedtrace",
     "stdio_ptr",
+    "sendmail",
+    "d_remainder",
+    "d_longdbl",
+    "Revision",
+    "d_siginfo_si_status",
+    "version",
+    "installsitebin",
+    "i_termio",
+    "h_fcntl",
+    "i_termios",
+    "d_builtin_expect",
     "d_getgrent_r",
-    "i_systypes",
+    "revision",
+    "uidtype",
+    "rd_nodata",
+    "d_isblank",
+    "usemallocwrap",
+    "setservent_r_proto",
+    "sitescript",
+    "endservent_r_proto",
+    "d_llround",
+    "byteorder",
+    "sitescriptexp",
+    "d_sysconf",
+    "pthread_h_first",
+    "u16type",
+    "d_strlcpy",
+    "u64type",
+    "d_random_r",
+    "setnetent_r_proto",
+    "endnetent_r_proto",
     "d_sqrtl",
-    "d_setproctitle",
-    "d_wcstombs",
-    "u32type",
-    "ccdlflags",
-    "static_ext",
-    "installsiteman1dir",
-    "d_sethent",
-    "d_endhent",
-    "groupcat",
-    "eunicefix",
-    "d_tm_tm_gmtoff",
-    "d_clearenv",
-    "usethreads",
-    "_exe",
-    "locincpth",
-    "d_locconv",
     "d_siginfo_si_fd",
-    "d_lgamma_r",
-    "d_gethname",
+    "d_tm_tm_gmtoff",
+    "u32type",
+    "d_inetpton",
+    "d_freelocale",
+    "d_llroundl",
+    "targetsh",
+    "d_strtoq",
+    "perlpath",
+    "d_stdiobase",
     "installhtml3dir",
-    "lddlflags",
+    "d_semop",
+    "d_clearenv",
+    "spitshell",
+    "d_pathconf",
+    "strerror_r_proto",
+    "path_sep",
+    "vendorman3dir",
+    "vendorman1dir",
     "d_sresuproto",
     "installhtml1dir",
-    "d_getnameinfo",
-    "i_socks",
-    "sockethdr",
-    "extras",
-    "Locker",
-    "d_llround",
-    "d_mkdir",
-    "mkdir",
-    "d_mktime",
-    "sGMTIME_max",
-    "cf_by",
-    "make",
-    "d_re_comp",
-    "sPRIx64",
-    "d_freelocale",
-    "d_msgget",
-    "d_pathconf",
-    "dlext",
-    "stdio_filbuf",
-    "d_dosuid",
-    "version",
-    "d_stdstdio",
     "vendorbin",
-    "d_old_pthread_create_joinable",
-    "d_PRIx64",
-    "full_csh",
-    "cppminus",
-    "vendorlib",
-    "expr",
-    "d_syscallproto",
-    "d_llroundl",
-    "d_semop",
-    "d_mktime64",
-    "vaproto",
-    "uniq",
-    "sLOCALTIME_max",
     "d_getprotoprotos",
-    "scriptdirexp",
-    "d_tmpnam_r",
-    "sched_yield",
-    "useithreads",
+    "installman3dir",
+    "installman1dir",
     "myuname",
-    "pmake",
-    "d_getnetbyname_r",
-    "d_quad",
-    "d_longlong",
-    "doublemantbits",
+    "d_sethent",
+    "d_endhent",
+    "d_tcsetpgrp",
+    "d_gethname",
+    "d_vendorbin",
+    "d_msgget",
+    "_exe",
+    "ccstdflags",
+    "d_pwcomment",
+    "baserev",
+    "sPRIx64",
+    "d_fchmod",
+    "sitebinexp",
+    "d_dir_dd_fd",
+    "vendorlib",
+    "privlib",
+    "d_pwgecos",
+    "usethreads",
+    "byacc",
+    "perl_static_inline",
+    "i_gdbmndbm",
+    "d_getpgid",
+    "u8size",
+    "extras",
+    "dlext",
+    "sGMTIME_max",
+    "installsiteman3dir",
+    "d_PRIx64",
+    "cppstdin",
+    "installsiteman1dir",
+    "d_vendorscript",
+    "d_malloc_size",
+    "bash",
+    "d_dosuid",
+    "d_syscall",
+    "d_stdstdio",
+    "d_sitearch",
+    "eunicefix",
+    "d_old_pthread_create_joinable",
     "i_sysstatfs",
-    "op_cflags",
-    "charbits",
-    "ansi2knr",
-    "nvsize",
-    "ivsize",
-    "i_arpainet",
-    "vendorman3dir",
-    "d_statvfs",
-    "gidtype",
-    "d_localtime64",
-    "d_siginfo_si_band",
-    "d_exp2",
-    "vendorman1dir",
-    "i_fenv",
-    "socketlib",
-    "setprotoent_r_proto",
-    "endprotoent_r_proto",
-    "installarchlib",
-    "archlibexp",
-    "d_setresuid",
     "ttyname_r_proto",
-    "usereentrant",
-    "d_readlink",
-    "i_stdlib",
-    "d_asctime_r",
-    "d_ttyname_r",
-    "setgrent_r_proto",
-    "endgrent_r_proto",
-    "d_asctime64",
+    "uniq",
+    "intsize",
+    "locincpth",
+    "vaproto",
+    "d_dbl_dig",
+    "cppflags",
+    "d_fpclassify",
+    "i_fenv",
+    "i16size",
+    "i64size",
+    "d_quad",
+    "d_setlocale_r",
+    "d_portable",
+    "d_wctomb",
+    "i32size",
+    "chgrp",
+    "cccdlflags",
+    "stdio_filbuf",
+    "d_setresuid",
+    "d_nl_langinfo",
+    "d_re_comp",
+    "sLOCALTIME_max",
+    "expr",
+    "d_getnameinfo",
+    "full_csh",
+    "lddlflags",
+    "d_exp2",
+    "d_localtime64",
     "mailx",
-    "d_closedir",
+    "selectminbits",
+    "netdb_host_type",
+    "gidtype",
+    "d_getnetbyname_r",
+    "d_fs_data_s",
+    "castflags",
+    "netdb_name_type",
+    "cppminus",
     "d_setpwent",
     "d_endpwent",
-    "cf_email",
+    "d_mbstowcs",
+    "libpth",
+    "d_fpos64_t",
+    "i_inttypes",
     "madlyh",
-    "libspath",
-    "nvmantbits",
-    "d_copysign",
-    "d_getnetent_r",
-    "db_hashtype",
-    "shmattype",
-    "baserev",
-    "alignbytes",
-    "d_getprotobyname_r",
-    "d_copysignl",
-    "d_tcgetpgrp",
-    "d_expm1",
-    "d_socklen_t",
-    "d_setreuid",
-    "git_remote_branch",
-    "d_fsetpos",
-    "d_sin6_scope_id",
-    "orderlib",
-    "d_sigaction",
-    "d_getpbynumber",
-    "myarchname",
-    "setlocale_r_proto",
-    "installbin",
     "i_vfork",
     "d_vfork",
-    "i_sysdir",
-    "d_shmget",
-    "git_describe",
+    "d_statfs_s",
+    "d_fsetpos",
+    "ptrsize",
+    "setprotoent_r_proto",
+    "endprotoent_r_proto",
     "d_pwclass",
-    "d_vsnprintf",
-    "d_snprintf",
-    "i_varargs",
-    "i_sysparam",
-    "d_wctomb",
-    "d_sprintf_returns_strlen",
-    "d_nearbyint",
-    "targetarch",
-    "fflushNULL",
-    "d_socket",
-    "d_fork",
-    "uvsize",
+    "targetenv",
+    "groupcat",
+    "scriptdirexp",
+    "nvmantbits",
+    "i_arpainet",
+    "signal_t",
     "d_volatile",
-    "d_oldpthreads",
-    "doop_cflags",
-    "flex",
-    "gccversion",
-    "getprotobyname_r_proto",
+    "d_expm1",
+    "sig_name_init",
+    "cf_by",
     "d_newlocale",
-    "d_getppid",
-    "d_gethostprotos",
-    "getnetent_r_proto",
-    "selectminbits",
-    "d_phostname",
-    "man3ext",
+    "ccsymbols",
+    "d_closedir",
+    "d_semctl_semun",
+    "d_syscallproto",
+    "d_semctl_semid_ds",
+    "i_sgtty",
+    "d_siginfo_si_band",
+    "ccdlflags",
+    "d_vsnprintf",
     "myhostname",
-    "d_setprotoent_r",
-    "d_endprotoent_r",
-    "d_stdio_cnt_lval",
-    "d_getpagsz",
-    "prefix",
-    "longdblmantbits",
-    "d_getgrnam_r",
-    "d_mbstowcs",
-    "man1ext",
-    "netdb_host_type",
-    "targetmkdir",
-    "d_pwcomment",
-    "i_rpcsvcdbm",
-    "installvendorscript",
-    "d_msgrcv",
-    "netdb_name_type",
-    "d_unsetenv",
-    "installsitelib",
     "sethostent_r_proto",
     "endhostent_r_proto",
-    "usedevel",
-    "d_pwgecos",
-    "d_setpwent_r",
-    "d_getnbyaddr",
-    "d_endpwent_r",
-    "need_va_copy",
-    "d_hypot",
-    "i_values",
-    "git_commit_id",
-    "targetport",
-    "d_gethent",
-    "usemallocwrap",
-    "d_vendorlib",
-    "setservent_r_proto",
-    "endservent_r_proto",
-    "phostname",
-    "d_fmax",
-    "usemymalloc",
-    "installhtmldir",
-    "vendorhtml3dir",
-    "ieeefp_h",
-    "d_vprintf",
-    "random_r_proto",
-    "loclibpth",
-    "d_fegetround",
-    "d_voidtty",
-    "d_getcwd",
-    "d_sockatmark",
-    "d_c99_variadic_macros",
-    "d_log1p",
-    "installvendorman3dir",
-    "installstyle",
-    "vendorhtml1dir",
-    "d_strxfrm",
-    "nvtype",
-    "ivtype",
-    "d_setregid",
-    "binexp",
-    "git_commit_id_title",
-    "gmake",
-    "d_regcomp",
-    "defvoidused",
-    "installvendorman1dir",
-    "issymlink",
-    "d_symlink",
-    "d_static_inline",
-    "db_version_minor",
-    "d_sockaddr_in6",
-    "nveformat",
-    "api_subversion",
-    "ivdformat",
-    "d_malloc_good_size",
-    "d_lockf",
-    "cppccsymbols",
-    "d_pthread_yield",
-    "tmpnam_r_proto",
-    "d_setvbuf",
-    "d_fpgetround",
-    "xlibpth",
-    "d_localtime_r",
-    "d_localtime_r_needs_tzset",
-    "d_ptrdiff_t",
-    "yaccflags",
-    "d_grpasswd",
-    "subversion",
-    "d_memmove",
-    "timetype",
-    "d_recvmsg",
-    "d_getnetbyaddr_r",
-    "shrpenv",
-    "madlyobj",
-    "targetenv",
-    "i_varhdr",
-    "d_union_semun",
-    "d_sigprocmask",
-    "i_shadow",
-    "installprivlib",
-    "privlibexp",
-    "html3dir",
-    "getprotoent_r_proto",
-    "d_getespwnam",
-    "d_xenix",
-    "getnetbyaddr_r_proto",
-    "lseektype",
-    "installsitearch",
-    "html1dir",
-    "ccflags_nolargefiles",
-    "getgrent_r_proto",
-    "chown",
-    "ksh",
-    "d_statfs_f_flags",
-    "sig_count",
+    "d_asctime_r",
+    "d_asctime64",
+    "d_seekdir",
+    "d_ttyname_r",
+    "cf_email",
+    "d_gmtime_r",
+    "doublemantbits",
     "d_pwage",
-    "d_getpwent",
-    "d_shmatprototype",
-    "uselongdouble",
-    "netdb_hlen_type",
-    "i_sysuio",
-    "d_setpgrp",
-    "getspnam_r_proto",
-    "ldflags_nolargefiles",
-    "mydomain",
-    "d_mbtowc",
-    "d_getprpwnam",
-    "randseedtype",
-    "installprefixexp",
-    "d_msghdr_s",
-    "modetype",
-    "d_voidsig",
-    "extern_C",
-    "d_memcpy",
-    "usesitecustomize",
-    "longdblnanbytes",
-    "libswanted",
-    "longdblinfbytes",
-    "d_strctcpy",
-    "lib_ext",
-    "d_sockatmarkproto",
-    "d_gettimeod",
-    "mallocobj",
-    "config_args",
-    "libsfound",
-    "d_getlogin",
-    "uvtype",
-    "d_setpgrp2",
-    "config_argc",
-    "config_arg8",
-    "config_arg3",
-    "config_arg6",
-    "cpp_stuff",
-    "config_arg39",
-    "d_setlinebuf",
-    "config_arg4",
-    "config_arg35",
-    "config_arg38",
-    "selecttype",
-    "config_arg30",
-    "config_arg33",
-    "spackage",
-    "config_arg0",
-    "config_arg37",
-    "clocktype",
-    "config_arg31",
-    "d_fgetpos",
-    "config_arg9",
-    "d_getsbyname",
-    "d_getnbyname",
-    "i_systime",
-    "config_arg5",
-    "i_systimes",
-    "sizetype",
-    "git_branch",
-    "config_arg1",
-    "config_arg36",
-    "config_arg19",
-    "config_arg32",
+    "useithreads",
+    "d_copysign",
+    "shrpenv",
+    "chown",
+    "d_link",
+    "op_cflags",
+    "i_shadow",
+    "d_setprotoent_r",
+    "d_c99_variadic_macros",
+    "d_endprotoent_r",
+    "d_sigaction",
+    "d_shmget",
+    "myarchname",
+    "d_getprotobyname_r",
+    "uidsize",
+    "i_varargs",
+    "d_setreuid",
+    "d_getpbynumber",
+    "d_copysignl",
+    "installarchlib",
+    "fflushNULL",
+    "d_unsetenv",
+    "u16size",
+    "u64size",
+    "git_remote_branch",
+    "d_lgamma_r",
+    "flex",
+    "i_rpcsvcdbm",
+    "d_getnetent_r",
     "d_chown",
-    "i_sysutsname",
-    "config_arg15",
-    "config_arg18",
-    "config_arg10",
-    "config_arg13",
-    "config_arg7",
-    "config_arg17",
-    "config_arg11",
-    "d_socks5_init",
-    "mmaptype",
-    "config_arg34",
-    "installvendorbin",
-    "config_arg16",
-    "d_fchdir",
-    "config_arg12",
+    "u32size",
+    "d_mkdir",
+    "gzip",
+    "d_mktime",
+    "setgrent_r_proto",
+    "endgrent_r_proto",
+    "make",
+    "mkdir",
+    "ansi2knr",
+    "man3ext",
+    "usedevel",
+    "man1ext",
     "d_getservprotos",
-    "st_ino_size",
-    "freetype",
-    "package",
-    "config_arg14",
-    "lkflags",
-    "i_langinfo",
-    "o_nonblock",
-    "config_arg2",
-    "d_safemcpy",
-    "config_arg29",
-    "d_safebcpy",
-    "config_arg25",
-    "config_arg28",
-    "config_arg20",
-    "config_arg23",
-    "nvGUformat",
-    "nvEUformat",
-    "d_getpbyname",
-    "config_arg27",
-    "nvFUformat",
-    "config_arg21",
-    "installvendorlib",
-    "config_arg26",
-    "config_arg22",
-    "config_arg24",
-    "nvfformat",
-    "cryptlib",
-    "d_sethostent_r",
-    "d_endhostent_r",
-    "d_getprotoent_r",
-    "perl_patchlevel",
-    "regexec_cflags",
-    "d_getspnam",
-    "db_prefixtype",
-    "hostgenerate",
-    "d_fstatvfs",
-    "uvoformat",
-    "git_commit_date",
-    "d_gnulibc",
-    "setpwent_r_proto",
-    "endpwent_r_proto",
-    "d_sigsetjmp",
-    "gethostent_r_proto",
-    "use64bitall",
-    "d_getpwent_r",
-    "i_sysvfs",
-    "d_getprotobynumber_r",
-    "d_lchown",
-    "i_gdbm_ndbm",
+    "mips_type",
+    "d_msgrcv",
+    "installvendorman3dir",
+    "d_oldpthreads",
+    "archlibexp",
+    "installvendorman1dir",
+    "i_sysdir",
+    "d_sprintf_returns_strlen",
+    "libswanted",
+    "i_values",
+    "d_mktime64",
+    "i_socks",
+    "i_stdlib",
+    "charbits",
+    "sockethdr",
+    "defvoidused",
+    "prototype",
+    "static_ext",
     "getservent_r_proto",
-    "gmtime_r_proto",
-    "d_printf_format_null",
-    "usemorebits",
-    "d_mkfifo",
-    "d_fcntl_can_lock",
-    "fflushall",
-    "versiononly",
-    "getnetbyname_r_proto",
-    "libs_nolargefiles",
-    "fpostype",
-    "st_ino_sign",
-    "direntrytype",
-    "procselfexe",
-    "i_xlocale",
-    "uselargefiles",
-    "d_getlogin_r",
-    "d_waitpid",
-    "d_pthread_attr_setscope",
-    "nvgformat",
-    "i_sysfile",
-    "uvuformat",
-    "d_nextafter",
-    "canned_gperf",
-    "uquadtype",
-    "malloctype",
-    "awk",
-    "localtime_r_proto",
-    "api_version",
-    "d_backtrace",
-    "uvXUformat",
-    "longlongsize",
-    "i_syswait",
-    "getgrnam_r_proto",
-    "d_bsdsetpgrp",
-    "ccversion",
-    "db_version_patch",
-    "dynamic_ext",
-    "sharpbang",
-    "i_quadmath",
-    "installsitescript",
-    "d_getspnam_r",
-    "d_builtin_choose_expr",
-    "installvendorarch",
-    "sitehtml3direxp",
-    "d_getpgrp",
-    "gethostbyname_r_proto",
-    "vendorarch",
-    "vendorscript",
-    "d_siginfo_si_value",
-    "vendorarchexp",
-    "d_vms_case_sensitive_symbols",
-    "getservbyname_r_proto",
-    "longdblsize",
-    "sitearchexp",
-    "api_revision",
-    "shortsize",
-    "d_gethbyaddr",
-    "sitehtml1direxp",
-    "make_set_make",
-    "usecbacktrace",
-    "d_fchown",
-    "d_getpgrp2",
-    "voidflags",
-    "ctime_r_proto",
-    "archobjs",
-    "ccwarnflags",
-    "libdb_needs_pthread",
-    "ldlibpthname",
-    "malloc_cflags",
-    "d_remquo",
-    "d_perl_otherlibdirs",
+    "Locker",
+    "targetport",
+    "vendorhtml3dir",
+    "vendorhtml1dir",
+    "getnetent_r_proto",
+    "d_log1p",
+    "d_fmax",
+    "getprotobyname_r_proto",
+    "nveformat",
+    "d_setpwent_r",
+    "d_endpwent_r",
+    "ivdformat",
+    "d_snprintf",
+    "d_getppid",
+    "prefix",
+    "netdb_hlen_type",
+    "d_readlink",
+    "libspath",
+    "installhtmldir",
+    "d_vprintf",
+    "d_union_semun",
+    "d_hypot",
     "d_setservent_r",
     "d_endservent_r",
-    "d_gethostbyaddr_r",
-    "extensions",
-    "installvendorhtml3dir",
-    "d_pwpasswd",
-    "d_ldexpl",
+    "d_memmove",
+    "installvendorscript",
+    "orderlib",
+    "d_gethostprotos",
+    "pmake",
+    "installstyle",
+    "d_gethent",
+    "d_tcgetpgrp",
+    "setlocale_r_proto",
+    "ldflags_nolargefiles",
+    "d_nearbyint",
+    "d_bzero",
+    "git_commit_id",
+    "installbin",
+    "nvtype",
+    "ivtype",
+    "usemymalloc",
+    "issymlink",
+    "d_symlink",
+    "d_strxfrm",
+    "doop_cflags",
+    "d_fegetround",
+    "d_phostname",
+    "d_socklen_t",
+    "git_commit_id_title",
+    "timetype",
+    "d_sigprocmask",
+    "d_getgrnam_r",
+    "d_sethostent_r",
+    "installsitelib",
+    "d_endhostent_r",
+    "gccversion",
+    "socketlib",
+    "gidsize",
+    "d_setregid",
+    "need_va_copy",
+    "d_stdio_cnt_lval",
+    "d_pthread_yield",
+    "targetarch",
+    "d_getcwd",
+    "d_tmpnam_r",
+    "modetype",
+    "phostname",
+    "longdblmantbits",
+    "api_subversion",
+    "d_waitpid",
+    "d_setvbuf",
+    "d_bcopy",
+    "ccflags_nolargefiles",
+    "d_regcomp",
+    "d_vendorlib",
+    "mydomain",
+    "git_describe",
+    "d_xenix",
+    "d_fork",
+    "madlyobj",
+    "loclibpth",
+    "i_varhdr",
+    "d_fpgetround",
+    "d_grpasswd",
+    "d_voidsig",
+    "sig_count",
+    "versiononly",
+    "d_getpwent",
+    "d_sin6_scope_id",
+    "i_sysuio",
+    "d_getnetbyaddr_r",
+    "i_sysparam",
+    "d_pthread_attr_setscope",
+    "d_ptrdiff_t",
+    "d_getnbyaddr",
+    "d_fgetpos",
+    "getprotoent_r_proto",
+    "d_recvmsg",
+    "d_gettimeod",
+    "d_shmatprototype",
+    "installprivlib",
+    "db_version_minor",
+    "d_socket",
+    "i_sysutsname",
+    "d_memcpy",
+    "setpwent_r_proto",
+    "html3dir",
+    "endpwent_r_proto",
+    "d_sched_yield",
+    "html1dir",
+    "installprefixexp",
+    "uvoformat",
+    "d_localtime_r",
+    "binexp",
+    "nvfformat",
+    "d_localtime_r_needs_tzset",
+    "d_getespwnam",
+    "gethostent_r_proto",
+    "mmaptype",
+    "privlibexp",
+    "randseedtype",
+    "uvtype",
+    "xlibpth",
+    "d_setpgrp",
+    "subversion",
+    "i_systime",
+    "i_systimes",
+    "api_revision",
+    "freetype",
+    "uselongdouble",
+    "d_getsbyname",
+    "d_getnbyname",
+    "libsfound",
+    "installsitearch",
+    "d_setpgrp2",
+    "vendorscript",
+    "d_getprotoent_r",
+    "i_systypes",
+    "targetmkdir",
+    "ctime_r_proto",
+    "selecttype",
+    "i_langinfo",
+    "d_mbtowc",
+    "nvEUformat",
+    "nvGUformat",
+    "nvFUformat",
+    "d_getprpwnam",
+    "i_syswait",
+    "getgrent_r_proto",
+    "hostgenerate",
+    "d_fstatvfs",
+    "gmake",
     "d_writev",
-    "installvendorhtml1dir",
-    "installsitehtml3dir",
-    "perl_revision",
-    "d_attribut",
-    "d_madvise",
-    "installsitehtml1dir",
     "vendorlib_stem",
+    "yaccflags",
+    "d_safemcpy",
+    "regexec_cflags",
+    "installvendorbin",
+    "getnetbyaddr_r_proto",
+    "d_getlogin",
+    "d_strctcpy",
+    "cpp_stuff",
+    "longdblinfbytes",
+    "d_getpbyname",
+    "i_sysvfs",
+    "lib_ext",
+    "installvendorlib",
+    "ieeefp_h",
+    "nvgformat",
+    "d_getpwent_r",
+    "uvuformat",
+    "d_lockf",
+    "fpostype",
+    "nvsize",
+    "ivsize",
+    "d_safebcpy",
+    "d_getservent_r",
+    "d_setlinebuf",
+    "git_commit_date",
+    "d_fchdir",
+    "procselfexe",
+    "d_static_inline",
+    "getnetbyname_r_proto",
+    "d_lchown",
+    "d_pwpasswd",
+    "malloctype",
+    "sched_yield",
+    "d_statfs_f_flags",
+    "awk",
+    "d_getspnam",
+    "i_sysfile",
+    "d_sockatmark",
     "d_gethostent_r",
-    "usekernprocpathname",
-    "d_getpwnam_r",
-    "d_getgrgid_r",
-    "getpwent_r_proto",
-    "shsharp",
-    "installhtmlhelpdir",
-    "d_ldbl_dig",
-    "patchlevel",
-    "useversionedarchname",
-    "d_flexfnam",
-    "vendorbinexp",
-    "inc_version_list",
-    "use64bitint",
-    "vendorlibexp",
-    "inc_version_list_init",
-    "d_gdbmndbm_h_uses_prototypes",
-    "toke_cflags",
-    "useposix",
-    "d_scm_rights",
-    "quadkind",
-    "ignore_versioned_solibs",
-    "d__fwalk",
-    "getservbyport_r_proto",
-    "d_gethbyname",
+    "direntrytype",
+    "dynamic_ext",
+    "fflushall",
+    "d_sockaddr_in6",
+    "ksh",
+    "usemorebits",
+    "d_vms_case_sensitive_symbols",
+    "uselargefiles",
+    "extern_C",
+    "d_msghdr_s",
+    "uvXUformat",
+    "d_siginfo_si_value",
+    "api_version",
+    "shmattype",
+    "db_prefixtype",
+    "getspnam_r_proto",
+    "localtime_r_proto",
+    "o_nonblock",
+    "random_r_proto",
+    "config_args",
+    "config_arg5",
+    "config_arg6",
+    "config_arg0",
+    "i_xlocale",
+    "d_getlogin_r",
+    "longdblnanbytes",
+    "config_arg3",
+    "config_arg7",
+    "d_gnulibc",
+    "config_arg32",
+    "config_arg1",
+    "config_arg33",
+    "config_arg4",
+    "config_arg12",
+    "config_arg13",
+    "config_arg2",
+    "config_arg39",
+    "config_arg22",
+    "config_arg23",
+    "config_arg19",
+    "d_remquo",
+    "lkflags",
+    "config_arg8",
+    "config_arg30",
+    "config_arg34",
+    "config_arg9",
+    "config_arg29",
+    "config_arg10",
+    "config_arg14",
+    "config_arg31",
     "git_uncommitted_changes",
+    "config_arg11",
+    "config_arg38",
+    "config_arg20",
+    "config_arg24",
+    "config_arg37",
+    "config_arg18",
+    "d_getprotobynumber_r",
+    "git_branch",
+    "config_arg21",
+    "config_arg17",
+    "config_arg35",
+    "d_sockatmarkproto",
+    "config_arg28",
+    "config_arg36",
+    "config_arg15",
+    "config_arg27",
+    "config_arg16",
+    "config_arg25",
+    "uvsize",
+    "config_arg26",
+    "i_quadmath",
+    "installvendorarch",
+    "ccwarnflags",
+    "ccversion",
+    "installsitescript",
+    "perl_patchlevel",
+    "d_nextafter",
+    "config_argc",
+    "getpwent_r_proto",
+    "d_mkfifo",
+    "installvendorhtml3dir",
+    "installvendorhtml1dir",
+    "cryptlib",
+    "alignbytes",
+    "d_voidtty",
+    "extensions",
+    "sitehtml3direxp",
     "sig_num_init",
-    "vendorman3direxp",
-    "gethostbyaddr_r_proto",
-    "db_version_major",
-    "d_bsdgetpgrp",
-    "vendorman1direxp",
-    "dtraceobject",
-    "firstmakefile",
-    "d_frexpl",
-    "perl_version",
-    "d_stdio_ptr_lval",
-    "d_vendorarch",
-    "d_stdio_ptr_lval_sets_cnt",
-    "groupstype",
-    "d_stdio_ptr_lval_nochange_cnt",
-    "exe_ext",
-    "lseeksize",
-    "ccflags_uselargefiles",
+    "sitehtml1direxp",
+    "tmpnam_r_proto",
+    "d_printf_format_null",
+    "d_getpgrp",
+    "d_fchown",
+    "d_bsdsetpgrp",
+    "d_sigsetjmp",
+    "d_getspnam_r",
+    "sitearchexp",
+    "d_getpgrp2",
+    "voidflags",
+    "mallocobj",
+    "package",
+    "vendorarch",
+    "d_ldexpl",
+    "vendorarchexp",
+    "spackage",
+    "use64bitall",
+    "gccosandvers",
+    "db_hashtype",
+    "ssizetype",
+    "d_madvise",
     "d_wcsxfrm",
-    "d_gdbm_ndbm_h_uses_prototypes",
-    "d_void_closedir",
-    "i_execinfo",
-    "d_killpg",
+    "d_usleepproto",
+    "st_ino_sign",
+    "vendorbinexp",
+    "libs_nolargefiles",
+    "d_builtin_prefetch",
+    "vendorlibexp",
+    "perl_revision",
+    "db_version_patch",
+    "d__fwalk",
+    "ldlibpthname",
+    "d_getnetprotos",
+    "d_getservbyport_r",
+    "d_getpagsz",
+    "crypt_r_proto",
+    "vendorman3direxp",
+    "vendorman1direxp",
+    "shsharp",
+    "d_getgrgid_r",
+    "patchlevel",
+    "d_gethbyaddr",
+    "getgrnam_r_proto",
+    "d_socks5_init",
+    "canned_gperf",
+    "d_fcntl_can_lock",
+    "d_charvspr",
+    "perl_version",
+    "useposix",
+    "d_flexfnam",
     "ldflags_uselargefiles",
+    "d_gethostbyaddr_r",
+    "d_getpwnam_r",
+    "d_attribut",
+    "i_gdbm_ndbm",
+    "d_scm_rights",
+    "d_frexpl",
+    "useversionedarchname",
+    "usesitecustomize",
+    "d_gethbyname",
+    "sharpbang",
+    "sizetype",
+    "d_builtin_choose_expr",
+    "groupstype",
+    "gmtime_r_proto",
+    "cppccsymbols",
+    "exe_ext",
+    "d_pwquota",
+    "doublenanbytes",
+    "inc_version_list",
+    "BuiltWithPatchPerl",
+    "usemultiplicity",
+    "inc_version_list_init",
+    "ccflags_uselargefiles",
+    "installsitehtml3dir",
+    "installsitehtml1dir",
+    "vendorprefix",
+    "libdb_needs_pthread",
+    "hash_func",
+    "malloc_cflags",
+    "usekernprocpathname",
+    "d_malloc_good_size",
+    "d_bsdgetpgrp",
+    "installhtmlhelpdir",
+    "use64bitint",
+    "i_execinfo",
+    "ignore_versioned_solibs",
+    "longlongsize",
+    "d_pwchange",
+    "d_stdio_ptr_lval",
+    "quadkind",
+    "d_stdio_ptr_lval_sets_cnt",
+    "d_stdio_ptr_lval_nochange_cnt",
+    "d_qgcvt",
+    "usecbacktrace",
+    "db_version_major",
+    "h_sysfile",
+    "d_perl_otherlibdirs",
+    "d_getsbyport",
+    "archobjs",
+    "getpwnam_r_proto",
+    "make_set_make",
     "usequadmath",
+    "lseektype",
+    "siteprefix",
+    "siteprefixexp",
+    "i_sysfilio",
+    "getservbyname_r_proto",
+    "uquadtype",
+    "vendorhtml3direxp",
+    "vendorhtml1direxp",
+    "dtraceobject",
+    "d_backtrace",
+    "quadtype",
+    "d_gdbmndbm_h_uses_prototypes",
+    "d_void_closedir",
+    "d_nv_preserves_uv",
+    "firstmakefile",
     "d_mkstemp",
     "d_mkstemps",
     "d_mkdtemp",
-    "d_getservbyport_r",
-    "hash_func",
-    "gccosandvers",
-    "d_sockaddr_sa_len",
-    "socksizetype",
+    "d_ldbl_dig",
+    "gnulibc_version",
     "getlogin_r_proto",
-    "d_sbrkproto",
-    "d_qgcvt",
-    "usemultiplicity",
-    "d_getservent_r",
+    "nonxs_ext",
+    "st_ino_size",
+    "toke_cflags",
     "usevfork",
-    "h_sysfile",
-    "d_charvspr",
-    "siteprefix",
-    "d_usleepproto",
-    "d_pwquota",
-    "siteprefixexp",
-    "gccansipedantic",
-    "crypt_r_proto",
-    "bootstrap_charset",
-    "d_pwchange",
-    "getpwnam_r_proto",
-    "vendorprefix",
-    "i_sysfilio",
+    "d_killpg",
     "obj_ext",
-    "d_attribute_deprecated",
+    "uvxformat",
+    "clocktype",
+    "shortsize",
+    "d_pwexpire",
+    "d_builtin_arith_overflow",
+    "git_unpushed",
+    "gccansipedantic",
+    "longdblsize",
+    "libswanted_nolargefiles",
+    "getservbyport_r_proto",
+    "socksizetype",
+    "d_nexttoward",
+    "d_sockaddr_sa_len",
+    "d_getpwuid_r",
+    "gethostbyname_r_proto",
     "d_ipv6_mreq",
-    "vendorhtml3direxp",
-    "d_getnetprotos",
-    "quadtype",
-    "vendorhtml1direxp",
-    "doublenanbytes",
-    "d_nv_preserves_uv",
-    "BuiltWithPatchPerl",
+    "d_vendorarch",
+    "d_sbrkproto",
+    "vendorscriptexp",
+    "bootstrap_charset",
+    "getprotobynumber_r_proto",
+    "libswanted_uselargefiles",
+    "d_attribute_format",
+    "usensgetexecutablepath",
+    "d_pthread_atfork",
+    "d_msg_peek",
+    "d_attribute_deprecated",
     "d_attribute_malloc",
+    "i_sysstatvfs",
+    "usevendorprefix",
     "i_systimek",
+    "getgrgid_r_proto",
     "d_attribute_unused",
     "d_attribute_pure",
-    "d_msg_peek",
-    "d_attribute_format",
-    "git_unpushed",
-    "getgrgid_r_proto",
+    "d_gdbm_ndbm_h_uses_prototypes",
+    "otherlibdirs",
     "d_attribute_warn_unused_result",
-    "nonxs_ext",
-    "d_builtin_arith_overflow",
-    "d_getpwuid_r",
-    "getprotobynumber_r_proto",
-    "uvxformat",
-    "longdblkind",
     "d_attribute_noreturn",
     "d_attribute_nonnull",
-    "d_getsbyport",
-    "d_libm_lib_version",
-    "usensgetexecutablepath",
-    "d_nexttoward",
-    "otherlibdirs",
-    "d_nv_zero_is_allbits_zero",
-    "d_sockpair",
-    "gnulibc_version",
-    "d_pthread_atfork",
-    "useshrplib",
-    "usevendorprefix",
     "html3direxp",
     "html1direxp",
-    "d_pwexpire",
-    "i_sysstatvfs",
-    "libswanted_nolargefiles",
-    "d_msg_proxy",
-    "config_heavy",
-    "getpwuid_r_proto",
-    "d_ndbm_h_uses_prototypes",
-    "vendorscriptexp",
-    "d_gethostbyname_r",
-    "libswanted_uselargefiles",
-    "d_ipv6_mreq_source",
-    "api_versionstring",
-    "perl_subversion",
-    "version_patchlevel_string",
-    "d_libname_unique",
     "d_modfl_pow32_bug",
+    "getpwuid_r_proto",
+    "perl_subversion",
+    "d_msg_proxy",
+    "gethostbyaddr_r_proto",
+    "longdblkind",
+    "useshrplib",
+    "version_patchlevel_string",
     "d_getservbyname_r",
+    "d_sockpair",
+    "api_versionstring",
+    "d_gethostbyname_r",
+    "lseeksize",
+    "d_libm_lib_version",
+    "config_heavy",
     "doubleinfbytes",
+    "d_libname_unique",
     "vendorprefixexp",
+    "d_nv_zero_is_allbits_zero",
+    "d_ipv6_mreq_source",
     "prefixexp",
     "dl_so_eq_ext",
-    "nv_preserves_uv_bits",
+    "d_ndbm_h_uses_prototypes",
+    "nv_overflows_integers_at",
     "known_extensions",
-    "nv_overflows_integers_at"
+    "nv_preserves_uv_bits"
   };
 #define stringpool ((const char *) &stringpool_contents)
 
@@ -2959,9 +2967,9 @@ Config_lookup (register const char *str, register unsigned int len)
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3,			T_INV,0,ALN64I"@@n@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8,			T_INV,0,ALN64I"@@c@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8,			T_INV,0,ALN64I"@@Id@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str9,			T_INV,0,ALN64I"@@Id@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str9,			T_INV,0,ALN64I"@@ARCH@@"},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str10,			T_INV,0,ALN64I"@@tee@@"},
 
@@ -2969,3811 +2977,3748 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str13,			T_INV,0,ALN64I"@@test@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str14,			T_INV,0,ALN64I"@@ARCH@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str16,			T_INV,0,ALN64I"@@cc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str18,			T_INV,0,ALN64I"@@Mcc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str19,			T_INV,0,ALN64I"@@tr@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str20,			T_INV,0,ALN64I"@@CONFIG@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str25,			T_INV,0,ALN64I"@@src@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str27,			T_INV,0,ALN64I"@@i_niin@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str31,			T_INV,0,ALN64I"@@d_nice@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str35,		T_INV,0,ALN64I"@@i_netdb@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str36,			T_INV,0,ALN64I"@@_a@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str39,			T_INV,0,ALN64I"@@d_rint@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str40,		T_INV,0,ALN64I"@@sGMTIME_min@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str41,			T_INV,0,ALN64I"@@Date@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str42,			T_INV,0,ALN64I"@@cat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str43,			T_INV,0,ALN64I"@@date@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str44,			T_INV,0,ALN64I"@@State@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str45,			T_INV,0,ALN64I"@@ar@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str48,			T_INV,0,ALN64I"@@d_nan@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str49,			T_INV,0,ALN64I"@@tar@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str50,		T_INV,0,ALN64I"@@SUBVERSION@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str52,			T_INV,0,ALN64I"@@d_stat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str53,		T_INV,0,ALN64I"@@d_ctermid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str54,		T_INV,0,ALN64I"@@i_assert@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str56,		T_INV,0,ALN64I"@@d_strerrm@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str57,		T_INV,0,ALN64I"@@d_asinh@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str61,		T_INV,0,ALN64I"@@d_strchr@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str62,		T_INV,0,ALN64I"@@startsh@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str64,			T_INV,0,ALN64I"@@Header@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str65,		T_INV,0,ALN64I"@@PERL_REVISION@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str66,			T_INV,0,ALN64I"@@dtrace@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str67,		T_INV,0,ALN64I"@@d_access@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str68,		T_INV,0,ALN64I"@@PERL_VERSION@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str69,		T_INV,0,ALN64I"@@d_rename@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str70,	T_INV,0,ALN64I"@@PERL_SUBVERSION@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str72,		T_INV,0,ALN64I"@@PATCHLEVEL@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str74,		T_INV,0,ALN64I"@@d_ctermid_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str76,		T_INV,0,ALN64I"@@d_readdir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str78,			T_INV,0,ALN64I"@@ls@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str79,			T_INV,0,ALN64I"@@ln@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str81,			T_INV,0,ALN64I"@@lns@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str82,			T_INV,0,ALN64I"@@ld@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str83,			T_INV,0,ALN64I"@@less@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str84,		T_INV,0,ALN64I"@@d_atanh@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str85,		T_INV,0,ALN64I"@@sPRIi64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str86,		T_INV,0,ALN64I"@@sPRId64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str87,			T_INV,0,ALN64I"@@line@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str88,			T_INV,0,ALN64I"@@lint@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str96,		T_INV,0,ALN64I"@@d_PRIXU64@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str21,			T_INV,0,ALN64I"@@CONFIG@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str97,		T_INV,0,ALN64I"@@d_readdir_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str24,			T_INV,0,ALN64I"@@i_niin@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str98,			T_INV,0,ALN64I"@@trnl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str25,		T_INV,0,ALN64I"@@sPRIi64@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str99,			T_INV,0,ALN64I"@@i_dld@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str26,		T_INV,0,ALN64I"@@sPRId64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str27,		T_INV,0,ALN64I"@@SUBVERSION@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str103,		T_INV,0,ALN64I"@@sitelib@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str31,			T_INV,0,ALN64I"@@tr@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str104,		T_INV,0,ALN64I"@@d_isless@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str106,		T_INV,0,ALN64I"@@d_select@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str107,			T_INV,0,ALN64I"@@dlsrc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str108,	T_INV,0,ALN64I"@@PERL_PATCHLEVEL@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str113,		T_INV,0,ALN64I"@@sPRIXU64@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str115,			T_INV,0,ALN64I"@@tail@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str32,		T_INV,0,ALN64I"@@d_PRIXU64@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str118,			T_INV,0,ALN64I"@@cp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str35,			T_INV,0,ALN64I"@@_a@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str123,		T_INV,0,ALN64I"@@d_PRIi64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str124,		T_INV,0,ALN64I"@@d_PRId64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str125,			T_INV,0,ALN64I"@@pr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str132,		T_INV,0,ALN64I"@@d_class@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str139,		T_INV,0,ALN64I"@@d_scalbn@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str38,	T_INV,0,ALN64I"@@PERL_SUBVERSION@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str141,		T_INV,0,ALN64I"@@d_srand48_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str40,		T_INV,0,ALN64I"@@PERL_VERSION@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str41,		T_INV,0,ALN64I"@@PATCHLEVEL@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str42,			T_INV,0,ALN64I"@@Date@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str43,		T_INV,0,ALN64I"@@PERL_REVISION@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str44,	T_INV,0,ALN64I"@@PERL_PATCHLEVEL@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str45,			T_INV,0,ALN64I"@@date@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str46,			T_INV,0,ALN64I"@@State@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str47,			T_INV,0,ALN64I"@@d_nan@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str48,			T_INV,0,ALN64I"@@d_rint@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str49,		T_INV,0,ALN64I"@@sGMTIME_min@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str51,			T_INV,0,ALN64I"@@d_stat@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str53,		T_INV,0,ALN64I"@@i_assert@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str56,		T_INV,0,ALN64I"@@d_asinh@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str59,			T_INV,0,ALN64I"@@ar@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str61,			T_INV,0,ALN64I"@@ls@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str62,			T_INV,0,ALN64I"@@ln@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str63,			T_INV,0,ALN64I"@@tar@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str64,			T_INV,0,ALN64I"@@lns@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str65,			T_INV,0,ALN64I"@@ld@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str66,			T_INV,0,ALN64I"@@less@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str145,		T_INV,0,ALN64I"@@d_drand48_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str70,			T_INV,0,ALN64I"@@line@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str71,			T_INV,0,ALN64I"@@lint@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str73,			T_INV,0,ALN64I"@@Header@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str75,		T_INV,0,ALN64I"@@sPRIXU64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str76,		T_INV,0,ALN64I"@@startsh@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str77,		T_INV,0,ALN64I"@@d_strerrm@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str79,			T_INV,0,ALN64I"@@i_dld@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str80,		T_INV,0,ALN64I"@@d_rename@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str82,		T_INV,0,ALN64I"@@d_PRIi64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str83,		T_INV,0,ALN64I"@@d_PRId64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str84,		T_INV,0,ALN64I"@@d_isless@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str85,		T_INV,0,ALN64I"@@d_atanh@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str86,		T_INV,0,ALN64I"@@d_select@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str87,		T_INV,0,ALN64I"@@d_readdir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str88,			T_INV,0,ALN64I"@@so@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str89,			T_INV,0,ALN64I"@@_o@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str90,			T_INV,0,ALN64I"@@to@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str148,		T_INV,0,ALN64I"@@d_dladdr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str153,		T_INV,0,ALN64I"@@d_strtod@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str154,		T_INV,0,ALN64I"@@scriptdir@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str157,		T_INV,0,ALN64I"@@sLOCALTIME_min@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str165,		T_INV,0,ALN64I"@@incpath@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str166,		T_INV,0,ALN64I"@@d_alarm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str174,		T_INV,0,ALN64I"@@d_sanemcmp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str178,		T_INV,0,ALN64I"@@d_strerror@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str181,		T_INV,0,ALN64I"@@d_telldir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str186,			T_INV,0,ALN64I"@@lp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str194,			T_INV,0,ALN64I"@@sleep@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str93,			T_INV,0,ALN64I"@@trnl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str201,			T_INV,0,ALN64I"@@lpr@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str100,			T_INV,0,ALN64I"@@tail@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str203,			T_INV,0,ALN64I"@@so@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str204,			T_INV,0,ALN64I"@@perl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str205,			T_INV,0,ALN64I"@@to@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str207,			T_INV,0,ALN64I"@@_o@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str214,		T_INV,0,ALN64I"@@d_statblks@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str216,		T_INV,0,ALN64I"@@drand01@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str217,			T_INV,0,ALN64I"@@nm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str222,			T_INV,0,ALN64I"@@sort@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str223,		T_INV,0,ALN64I"@@d_strtol@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str226,		T_INV,0,ALN64I"@@d_strtold@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str228,			T_INV,0,ALN64I"@@cpp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str229,			T_INV,0,ALN64I"@@rm@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str230,		T_INV,0,ALN64I"@@sitelib_stem@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str231,			T_INV,0,ALN64I"@@d_sem@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str233,		T_INV,0,ALN64I"@@i_stdint@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str237,			T_INV,0,ALN64I"@@i_time@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str238,			T_INV,0,ALN64I"@@d_time@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str240,			T_INV,0,ALN64I"@@d_pipe@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str242,		T_INV,0,ALN64I"@@d_times@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str243,			T_INV,0,ALN64I"@@perl5@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str245,		T_INV,0,ALN64I"@@i_dirent@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str250,			T_INV,0,ALN64I"@@mad@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str253,		T_INV,0,ALN64I"@@d_isnan@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str254,		T_INV,0,ALN64I"@@d_rmdir@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str257,			T_INV,0,ALN64I"@@emacs@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str258,		T_INV,0,ALN64I"@@d_acosh@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str263,		T_INV,0,ALN64I"@@d_setprior@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str266,			T_INV,0,ALN64I"@@ccname@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str268,		T_INV,0,ALN64I"@@d_aintl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str269,		T_INV,0,ALN64I"@@stdio_base@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str272,		T_INV,0,ALN64I"@@man3dir@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str106,		T_INV,0,ALN64I"@@sPRIo64@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str281,		T_INV,0,ALN64I"@@sPRIo64@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str290,		T_INV,0,ALN64I"@@d_srandom_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str295,		T_INV,0,ALN64I"@@perllibs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str115,		T_INV,0,ALN64I"@@i_stdint@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str306,		T_INV,0,ALN64I"@@man1dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str316,		T_INV,0,ALN64I"@@timeincl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str317,		T_INV,0,ALN64I"@@d_dlerror@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str117,		T_INV,0,ALN64I"@@d_readdir_r@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str319,		T_INV,0,ALN64I"@@d_PRIo64@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str324,			T_INV,0,ALN64I"@@cpio@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str325,			T_INV,0,ALN64I"@@mail@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str327,			T_INV,0,ALN64I"@@smail@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str329,		T_INV,0,ALN64I"@@d_isnanl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str337,		T_INV,0,ALN64I"@@sPRIGUldbl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str338,		T_INV,0,ALN64I"@@sPRIEUldbl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str340,			T_INV,0,ALN64I"@@rmail@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str341,			T_INV,0,ALN64I"@@i_prot@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str342,		T_INV,0,ALN64I"@@sPRIFUldbl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str119,			T_INV,0,ALN64I"@@sort@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str345,		T_INV,0,ALN64I"@@d_PRIeldbl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str349,		T_INV,0,ALN64I"@@d_open3@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str353,		T_INV,0,ALN64I"@@d_scalbnl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str122,		T_INV,0,ALN64I"@@drand01@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str363,		T_INV,0,ALN64I"@@d_prctl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str136,			T_INV,0,ALN64I"@@c@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str137,		T_INV,0,ALN64I"@@d_isnan@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str365,		T_INV,0,ALN64I"@@installscript@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str139,		T_INV,0,ALN64I"@@i_dirent@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str142,		T_INV,0,ALN64I"@@d_dladdr@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str367,		T_INV,0,ALN64I"@@d_ip_mreq@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str144,		T_INV,0,ALN64I"@@d_telldir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str153,			T_INV,0,ALN64I"@@nm@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str156,			T_INV,0,ALN64I"@@d_nice@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str389,		T_INV,0,ALN64I"@@d_llrint@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str160,		T_INV,0,ALN64I"@@i_netdb@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str162,		T_INV,0,ALN64I"@@d_alarm@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str163,		T_INV,0,ALN64I"@@d_PRIo64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str164,			T_INV,0,ALN64I"@@d_sem@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str165,			T_INV,0,ALN64I"@@src@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str170,			T_INV,0,ALN64I"@@i_time@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str171,			T_INV,0,ALN64I"@@d_time@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str172,			T_INV,0,ALN64I"@@cat@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str175,		T_INV,0,ALN64I"@@d_times@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str177,			T_INV,0,ALN64I"@@rm@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str188,			T_INV,0,ALN64I"@@mad@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str190,		T_INV,0,ALN64I"@@d_ctermid@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str193,		T_INV,0,ALN64I"@@d_srand48_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str194,		T_INV,0,ALN64I"@@d_dlerror@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str195,		T_INV,0,ALN64I"@@d_srandom_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str196,		T_INV,0,ALN64I"@@d_isnanl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str197,		T_INV,0,ALN64I"@@d_drand48_r@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str199,		T_INV,0,ALN64I"@@d_rmdir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str203,		T_INV,0,ALN64I"@@d_aintl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str208,			T_INV,0,ALN64I"@@dtrace@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str210,		T_INV,0,ALN64I"@@d_strchr@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str212,			T_INV,0,ALN64I"@@pr@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str214,		T_INV,0,ALN64I"@@sitelib@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str216,		T_INV,0,ALN64I"@@sLOCALTIME_min@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str220,		T_INV,0,ALN64I"@@d_ctermid_r@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str222,		T_INV,0,ALN64I"@@i_neterrno@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str224,		T_INV,0,ALN64I"@@man3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str229,		T_INV,0,ALN64I"@@man1dir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str230,			T_INV,0,ALN64I"@@dlsrc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str235,		T_INV,0,ALN64I"@@timeincl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str237,		T_INV,0,ALN64I"@@d_strtod@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str242,		T_INV,0,ALN64I"@@d_class@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str244,			T_INV,0,ALN64I"@@lp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str246,			T_INV,0,ALN64I"@@mail@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str248,			T_INV,0,ALN64I"@@smail@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str249,		T_INV,0,ALN64I"@@d_llrint@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str252,			T_INV,0,ALN64I"@@sleep@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str258,		T_INV,0,ALN64I"@@i_mntent@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str266,			T_INV,0,ALN64I"@@more@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str270,		T_INV,0,ALN64I"@@d_acosh@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str271,			T_INV,0,ALN64I"@@lpr@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str272,			T_INV,0,ALN64I"@@cc@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str273,			T_INV,0,ALN64I"@@rmail@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str274,			T_INV,0,ALN64I"@@perl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str276,			T_INV,0,ALN64I"@@osname@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str278,			T_INV,0,ALN64I"@@perl5@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str279,			T_INV,0,ALN64I"@@Mcc@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str281,		T_INV,0,ALN64I"@@stdio_base@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str286,		T_INV,0,ALN64I"@@d_strerror@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str290,		T_INV,0,ALN64I"@@d_strtol@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str293,		T_INV,0,ALN64I"@@d_strtold@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str298,		T_INV,0,ALN64I"@@installscript@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str307,		T_INV,0,ALN64I"@@d_statblks@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str310,			T_INV,0,ALN64I"@@i_prot@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str319,		T_INV,0,ALN64I"@@d_open3@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str321,			T_INV,0,ALN64I"@@cp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str322,		T_INV,0,ALN64I"@@d_access@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str323,			T_INV,0,ALN64I"@@emacs@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str340,		T_INV,0,ALN64I"@@d_atoll@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str343,		T_INV,0,ALN64I"@@siteman3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str348,		T_INV,0,ALN64I"@@siteman1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str354,		T_INV,0,ALN64I"@@contains@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str365,		T_INV,0,ALN64I"@@sPRIEUldbl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str367,		T_INV,0,ALN64I"@@sPRIGUldbl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str369,		T_INV,0,ALN64I"@@scriptdir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str370,		T_INV,0,ALN64I"@@incpath@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str371,		T_INV,0,ALN64I"@@d_PRIeldbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str372,		T_INV,0,ALN64I"@@sPRIFUldbl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str376,		T_INV,0,ALN64I"@@d_sanemcmp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str377,		T_INV,0,ALN64I"@@d_scalbn@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str384,		T_INV,0,ALN64I"@@d_ip_mreq@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str387,			T_INV,0,ALN64I"@@d_pipe@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str417,	T_INV,0,ALN64I"@@d_ip_mreq_source@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str397,			T_INV,0,ALN64I"@@i_poll@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str398,			T_INV,0,ALN64I"@@d_poll@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str399,		T_INV,0,ALN64I"@@d_llrintl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str406,		T_INV,0,ALN64I"@@perladmin@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str412,			T_INV,0,ALN64I"@@cpio@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str413,		T_INV,0,ALN64I"@@sitelib_stem@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str422,		T_INV,0,ALN64I"@@d_setprior@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str431,			T_INV,0,ALN64I"@@nm_opt@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str439,		T_INV,0,ALN64I"@@d_lseekproto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str440,		T_INV,0,ALN64I"@@d_strtoll@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str442,		T_INV,0,ALN64I"@@sPRIu64@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str443,		T_INV,0,ALN64I"@@optimize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str450,		T_INV,0,ALN64I"@@dlltool@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str451,		T_INV,0,ALN64I"@@d_eunice@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str452,			T_INV,0,ALN64I"@@run@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str456,		T_INV,0,ALN64I"@@d_int64_t@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str460,			T_INV,0,ALN64I"@@ccname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str470,		T_INV,0,ALN64I"@@d_telldirproto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str471,		T_INV,0,ALN64I"@@d_trunc@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str474,		T_INV,0,ALN64I"@@i_locale@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str476,		T_INV,0,ALN64I"@@perllibs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str480,		T_INV,0,ALN64I"@@d_memchr@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str483,		T_INV,0,ALN64I"@@d_setitimer@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str484,		T_INV,0,ALN64I"@@d_inetntop@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str492,			T_INV,0,ALN64I"@@usedl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str493,		T_INV,0,ALN64I"@@d_drand48proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str499,		T_INV,0,ALN64I"@@d_PRIu64@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str501,		T_INV,0,ALN64I"@@use5005threads@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str506,			T_INV,0,ALN64I"@@cpp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str511,		T_INV,0,ALN64I"@@d_prctl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str522,			T_INV,0,ALN64I"@@comm@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str525,		T_INV,0,ALN64I"@@d_lrint@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str526,			T_INV,0,ALN64I"@@d_mmap@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str527,		T_INV,0,ALN64I"@@d_scalbnl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str528,		T_INV,0,ALN64I"@@d_lstat@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str530,		T_INV,0,ALN64I"@@d_truncl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str537,		T_INV,0,ALN64I"@@stdio_cnt@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str540,			T_INV,0,ALN64I"@@find@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str542,		T_INV,0,ALN64I"@@d_oldsock@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str544,		T_INV,0,ALN64I"@@i_netinet_ip@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str545,		T_INV,0,ALN64I"@@i_netinet_ip6@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str550,		T_INV,0,ALN64I"@@d_round@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str559,		T_INV,0,ALN64I"@@mallocsrc@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str560,			T_INV,0,ALN64I"@@afs@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str561,		T_INV,0,ALN64I"@@d_strlcat@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str564,		T_INV,0,ALN64I"@@d_unordered@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str565,			T_INV,0,ALN64I"@@d_erf@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str572,		T_INV,0,ALN64I"@@d_strcoll@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str576,		T_INV,0,ALN64I"@@d_dirfd@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str580,			T_INV,0,ALN64I"@@usenm@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str582,		T_INV,0,ALN64I"@@d_cuserid@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str583,	T_INV,0,ALN64I"@@d_ip_mreq_source@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str584,		T_INV,0,ALN64I"@@d_lrintl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str593,		T_INV,0,ALN64I"@@compress@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str595,			T_INV,0,ALN64I"@@usrinc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str605,			T_INV,0,ALN64I"@@runnm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str609,		T_INV,0,ALN64I"@@i_netinet6_in6@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str610,			T_INV,0,ALN64I"@@uname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str627,			T_INV,0,ALN64I"@@i_sfio@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str628,			T_INV,0,ALN64I"@@d_sfio@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str629,		T_INV,0,ALN64I"@@i_malloc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str636,		T_INV,0,ALN64I"@@d_memcmp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str651,		T_INV,0,ALN64I"@@i_limits@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str658,		T_INV,0,ALN64I"@@d_const@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str662,			T_INV,0,ALN64I"@@d_dup2@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str674,		T_INV,0,ALN64I"@@d_umask@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str675,		T_INV,0,ALN64I"@@d_faststdio@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str676,		T_INV,0,ALN64I"@@i_netinettcp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str677,			T_INV,0,ALN64I"@@Source@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str680,		T_INV,0,ALN64I"@@d_strtouq@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str684,	T_INV,0,ALN64I"@@initialinstalllocation@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str688,		T_INV,0,ALN64I"@@d_fseeko@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str693,			T_INV,0,ALN64I"@@d_fmin@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str695,		T_INV,0,ALN64I"@@d_lround@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str696,			T_INV,0,ALN64I"@@d_fdim@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str701,			T_INV,0,ALN64I"@@d_erfc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str706,		T_INV,0,ALN64I"@@d_ualarm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str711,		T_INV,0,ALN64I"@@d_strerror_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str712,		T_INV,0,ALN64I"@@usesocks@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str717,			T_INV,0,ALN64I"@@d_fma@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str719,			T_INV,0,ALN64I"@@i_fp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str720,		T_INV,0,ALN64I"@@ppmarch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str433,			T_INV,0,ALN64I"@@more@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str437,		T_INV,0,ALN64I"@@d_strtoll@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str440,		T_INV,0,ALN64I"@@i_mntent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str441,		T_INV,0,ALN64I"@@d_strcoll@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str443,		T_INV,0,ALN64I"@@i_neterrno@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str446,			T_INV,0,ALN64I"@@run@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str449,		T_INV,0,ALN64I"@@perladmin@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str452,		T_INV,0,ALN64I"@@d_inetntop@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str453,			T_INV,0,ALN64I"@@osname@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str454,		T_INV,0,ALN64I"@@contains@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str781,		T_INV,0,ALN64I"@@d_semctl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str460,		T_INV,0,ALN64I"@@d_eunice@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str461,			T_INV,0,ALN64I"@@usrinc@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str787,	T_INV,0,ALN64I"@@readdir_r_proto@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str463,		T_INV,0,ALN64I"@@d_cuserid@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str466,		T_INV,0,ALN64I"@@d_drand48proto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str468,		T_INV,0,ALN64I"@@d_trunc@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str471,		T_INV,0,ALN64I"@@d_memchr@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str474,			T_INV,0,ALN64I"@@i_poll@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str475,			T_INV,0,ALN64I"@@d_poll@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str789,			T_INV,0,ALN64I"@@from@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str480,		T_INV,0,ALN64I"@@d_setitimer@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str491,		T_INV,0,ALN64I"@@d_oldsock@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str492,		T_INV,0,ALN64I"@@ppmarch@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str494,		T_INV,0,ALN64I"@@siteman3dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str504,		T_INV,0,ALN64I"@@d_lseekproto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str508,		T_INV,0,ALN64I"@@sPRIu64@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str510,		T_INV,0,ALN64I"@@d_int64_t@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str515,			T_INV,0,ALN64I"@@usedl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str803,		T_INV,0,ALN64I"@@d_strtoul@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str523,		T_INV,0,ALN64I"@@d_telldirproto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str811,		T_INV,0,ALN64I"@@passcat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str812,		T_INV,0,ALN64I"@@usecperl@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str525,		T_INV,0,ALN64I"@@i_malloc@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str814,		T_INV,0,ALN64I"@@fpossize@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str528,		T_INV,0,ALN64I"@@siteman1dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str537,		T_INV,0,ALN64I"@@d_atoll@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str538,			T_INV,0,ALN64I"@@nm_opt@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str539,		T_INV,0,ALN64I"@@d_lrint@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str543,		T_INV,0,ALN64I"@@i_locale@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str544,		T_INV,0,ALN64I"@@d_truncl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str546,		T_INV,0,ALN64I"@@d_PRIu64@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str815,		T_INV,0,ALN64I"@@multiarch@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str552,		T_INV,0,ALN64I"@@d_lstat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str553,			T_INV,0,ALN64I"@@i8size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str557,		T_INV,0,ALN64I"@@compress@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str560,		T_INV,0,ALN64I"@@optimize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str564,		T_INV,0,ALN64I"@@d_memcmp@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str567,		T_INV,0,ALN64I"@@sizesize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str571,			T_INV,0,ALN64I"@@zcat@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str573,		T_INV,0,ALN64I"@@d_strlcat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str577,		T_INV,0,ALN64I"@@use5005threads@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str580,			T_INV,0,ALN64I"@@d_mmap@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str584,		T_INV,0,ALN64I"@@d_tzname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str589,			T_INV,0,ALN64I"@@find@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str590,		T_INV,0,ALN64I"@@d_strtouq@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str603,		T_INV,0,ALN64I"@@d_llrintl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str605,			T_INV,0,ALN64I"@@d_erf@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str607,			T_INV,0,ALN64I"@@afs@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str610,		T_INV,0,ALN64I"@@passcat@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str612,		T_INV,0,ALN64I"@@d_strerror_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str613,			T_INV,0,ALN64I"@@d_erfc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str615,		T_INV,0,ALN64I"@@d_lrintl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str616,		T_INV,0,ALN64I"@@d_dirfd@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str630,		T_INV,0,ALN64I"@@mallocsrc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str632,		T_INV,0,ALN64I"@@usecperl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str637,			T_INV,0,ALN64I"@@comm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str642,		T_INV,0,ALN64I"@@d_eaccess@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str644,			T_INV,0,ALN64I"@@zip@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str821,		T_INV,0,ALN64I"@@i_dlfcn@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str650,			T_INV,0,ALN64I"@@usenm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str827,		T_INV,0,ALN64I"@@i_fcntl@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str654,		T_INV,0,ALN64I"@@d_const@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str658,			T_INV,0,ALN64I"@@Source@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str661,		T_INV,0,ALN64I"@@stdio_cnt@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str662,		T_INV,0,ALN64I"@@d_round@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str663,			T_INV,0,ALN64I"@@runnm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str672,		T_INV,0,ALN64I"@@i_netinettcp@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str674,			T_INV,0,ALN64I"@@cpprun@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str676,		T_INV,0,ALN64I"@@d_unordered@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str678,			T_INV,0,ALN64I"@@uname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str684,			T_INV,0,ALN64I"@@d_dup2@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str696,			T_INV,0,ALN64I"@@i_fp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str722,		T_INV,0,ALN64I"@@usesocks@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str741,		T_INV,0,ALN64I"@@i_limits@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str743,		T_INV,0,ALN64I"@@d_semctl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str754,		T_INV,0,ALN64I"@@d_strlcpy@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str762,		T_INV,0,ALN64I"@@d_umask@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str764,		T_INV,0,ALN64I"@@cpplast@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str772,		T_INV,0,ALN64I"@@multiarch@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str774,			T_INV,0,ALN64I"@@bin@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str778,		T_INV,0,ALN64I"@@dlltool@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str783,			T_INV,0,ALN64I"@@i_db@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str786,			T_INV,0,ALN64I"@@d_bsd@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str789,		T_INV,0,ALN64I"@@d_strtoul@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str792,		T_INV,0,ALN64I"@@d_ualarm@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str793,		T_INV,0,ALN64I"@@bin_ELF@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str794,			T_INV,0,ALN64I"@@i_sfio@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str795,			T_INV,0,ALN64I"@@d_sfio@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str796,			T_INV,0,ALN64I"@@ebcdic@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str805,			T_INV,0,ALN64I"@@d_cbrt@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str809,			T_INV,0,ALN64I"@@d_fmin@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str812,			T_INV,0,ALN64I"@@d_fdim@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str815,		T_INV,0,ALN64I"@@i_fcntl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str816,		T_INV,0,ALN64I"@@d_fcntl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str825,	T_INV,0,ALN64I"@@readdir_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str826,		T_INV,0,ALN64I"@@d_ctime_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str831,			T_INV,0,ALN64I"@@d_fma@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str840,		T_INV,0,ALN64I"@@d_faststdio@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str844,		T_INV,0,ALN64I"@@i_mallocmalloc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str846,			T_INV,0,ALN64I"@@tbl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str847,		T_INV,0,ALN64I"@@PERL_CONFIG_SH@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str849,			T_INV,0,ALN64I"@@libs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str854,		T_INV,0,ALN64I"@@d_isinf@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str855,			T_INV,0,ALN64I"@@libc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str860,		T_INV,0,ALN64I"@@strings@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str864,		T_INV,0,ALN64I"@@libsdirs@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str865,		T_INV,0,ALN64I"@@d_strtoull@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str868,		T_INV,0,ALN64I"@@sig_size@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str869,	T_INV,0,ALN64I"@@srand48_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str870,		T_INV,0,ALN64I"@@d_ctime64@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str872,		T_INV,0,ALN64I"@@d_fseeko@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str873,	T_INV,0,ALN64I"@@drand48_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str876,		T_INV,0,ALN64I"@@d_readdir64_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str877,		T_INV,0,ALN64I"@@i_dlfcn@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str879,		T_INV,0,ALN64I"@@sig_name@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str880,	T_INV,0,ALN64I"@@initialinstalllocation@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str882,		T_INV,0,ALN64I"@@i_stdarg@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str883,		T_INV,0,ALN64I"@@i_unistd@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str828,		T_INV,0,ALN64I"@@d_fcntl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str890,		T_INV,0,ALN64I"@@useperlio@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str835,		T_INV,0,ALN64I"@@d_ctime_r@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str837,		T_INV,0,ALN64I"@@d_ftello@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str893,		T_INV,0,ALN64I"@@targetdir@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str840,		T_INV,0,ALN64I"@@d_ctime64@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str895,			T_INV,0,ALN64I"@@ranlib@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str844,		T_INV,0,ALN64I"@@d_memset@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str845,		T_INV,0,ALN64I"@@d_lroundl@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str898,			T_INV,0,ALN64I"@@eagain@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str899,		T_INV,0,ALN64I"@@d_SCNfldbl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str901,		T_INV,0,ALN64I"@@d_getaddrinfo@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str903,		T_INV,0,ALN64I"@@i_ustat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str904,		T_INV,0,ALN64I"@@d_ustat@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str848,		T_INV,0,ALN64I"@@d_eaccess@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str910,		T_INV,0,ALN64I"@@d_inetaton@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str854,		T_INV,0,ALN64I"@@mistrustnm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str858,		T_INV,0,ALN64I"@@d_isinf@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str859,		T_INV,0,ALN64I"@@sig_size@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str862,		T_INV,0,ALN64I"@@d_strtoull@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str863,	T_INV,0,ALN64I"@@srand48_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str865,	T_INV,0,ALN64I"@@srandom_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str867,	T_INV,0,ALN64I"@@drand48_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str868,		T_INV,0,ALN64I"@@i_unistd@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str916,		T_INV,0,ALN64I"@@fpossize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str874,		T_INV,0,ALN64I"@@d_dlopen@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str917,		T_INV,0,ALN64I"@@d_PRIfldbl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str875,		T_INV,0,ALN64I"@@d_flock@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str879,		T_INV,0,ALN64I"@@strings@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str881,		T_INV,0,ALN64I"@@d_eofnblk@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str885,		T_INV,0,ALN64I"@@sig_name@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str888,		T_INV,0,ALN64I"@@i_stdarg@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str890,		T_INV,0,ALN64I"@@i_ustat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str891,		T_INV,0,ALN64I"@@d_ustat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str892,		T_INV,0,ALN64I"@@d_mprotect@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str893,		T_INV,0,ALN64I"@@d_SCNfldbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str894,		T_INV,0,ALN64I"@@d_PRIfldbl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str907,		T_INV,0,ALN64I"@@d_getaddrinfo@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str909,			T_INV,0,ALN64I"@@eagain@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str914,		T_INV,0,ALN64I"@@targetdir@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str929,		T_INV,0,ALN64I"@@d_truncate@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str930,		T_INV,0,ALN64I"@@d_isinfl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str917,		T_INV,0,ALN64I"@@d_isinfl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str937,			T_INV,0,ALN64I"@@pg@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str924,			T_INV,0,ALN64I"@@Log@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str939,		T_INV,0,ALN64I"@@d_lround@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str927,		T_INV,0,ALN64I"@@d_modfl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str928,		T_INV,0,ALN64I"@@d_truncate@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str948,		T_INV,0,ALN64I"@@d_flock@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str946,		T_INV,0,ALN64I"@@i_mallocmalloc@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str954,		T_INV,0,ALN64I"@@d_eofnblk@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str955,			T_INV,0,ALN64I"@@grep@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str947,		T_INV,0,ALN64I"@@d_setgrent@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str958,			T_INV,0,ALN64I"@@egrep@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str960,		T_INV,0,ALN64I"@@i_fp_class@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str961,		T_INV,0,ALN64I"@@d_fp_class@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str962,		T_INV,0,ALN64I"@@i_ieeefp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str963,			T_INV,0,ALN64I"@@i_grp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str964,		T_INV,0,ALN64I"@@d_setgrps@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str965,		T_INV,0,ALN64I"@@d_PRIGUldbl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str966,		T_INV,0,ALN64I"@@d_PRIEUldbl@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str969,		T_INV,0,ALN64I"@@startperl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str970,		T_INV,0,ALN64I"@@d_PRIFUldbl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str972,		T_INV,0,ALN64I"@@d_fp_classify@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str976,			T_INV,0,ALN64I"@@u8size@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str977,			T_INV,0,ALN64I"@@bison@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str978,		T_INV,0,ALN64I"@@d_regcmp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str983,		T_INV,0,ALN64I"@@d_dlopen@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str985,			T_INV,0,ALN64I"@@pager@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str986,		T_INV,0,ALN64I"@@sitebin@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str950,		T_INV,0,ALN64I"@@d_endgrent@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str993,		T_INV,0,ALN64I"@@d_mprotect@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str957,		T_INV,0,ALN64I"@@startperl@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str997,			T_INV,0,ALN64I"@@i_dbm@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1000,			T_INV,0,ALN64I"@@i_ndbm@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1001,			T_INV,0,ALN64I"@@d_ndbm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1005,			T_INV,0,ALN64I"@@from@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1010,	T_INV,0,ALN64I"@@ctermid_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str958,			T_INV,0,ALN64I"@@cpprun@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1018,	T_INV,0,ALN64I"@@srandom_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str966,		T_INV,0,ALN64I"@@i_string@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str971,		T_INV,0,ALN64I"@@d_setsent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str972,		T_INV,0,ALN64I"@@d_setnent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str973,		T_INV,0,ALN64I"@@d_finite@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str974,		T_INV,0,ALN64I"@@d_endsent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str975,		T_INV,0,ALN64I"@@d_endnent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str976,		T_INV,0,ALN64I"@@d_futimes@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1024,		T_INV,0,ALN64I"@@d_memset@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1029,		T_INV,0,ALN64I"@@d_setsent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1030,		T_INV,0,ALN64I"@@d_setnent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1031,		T_INV,0,ALN64I"@@d_finite@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1032,		T_INV,0,ALN64I"@@d_endsent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1033,		T_INV,0,ALN64I"@@d_endnent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1034,		T_INV,0,ALN64I"@@d_futimes@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1036,			T_INV,0,ALN64I"@@Log@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1037,		T_INV,0,ALN64I"@@d_fp_classl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str982,		T_INV,0,ALN64I"@@useperlio@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1044,		T_INV,0,ALN64I"@@d_fds_bits@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str989,	T_INV,0,ALN64I"@@usecrosscompile@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1047,		T_INV,0,ALN64I"@@d_strftime@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1055,			T_INV,0,ALN64I"@@d_msg@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1058,		T_INV,0,ALN64I"@@d_setgrent@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str995,			T_INV,0,ALN64I"@@d_msg@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1060,		T_INV,0,ALN64I"@@d_setlocale@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1061,		T_INV,0,ALN64I"@@d_endgrent@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str997,		T_INV,0,ALN64I"@@longsize@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1065,		T_INV,0,ALN64I"@@i_string@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1001,		T_INV,0,ALN64I"@@d_strftime@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1003,		T_INV,0,ALN64I"@@targethost@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1019,			T_INV,0,ALN64I"@@pg@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1076,		T_INV,0,ALN64I"@@plibpth@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1080,		T_INV,0,ALN64I"@@nm_so_opt@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1084,		T_INV,0,ALN64I"@@d_cmsghdr_s@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1085,		T_INV,0,ALN64I"@@d_ftello@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1021,		T_INV,0,ALN64I"@@cpplast@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1088,		T_INV,0,ALN64I"@@d_getprior@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1090,		T_INV,0,ALN64I"@@sPRIeldbl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1091,		T_INV,0,ALN64I"@@mistrustnm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1097,		T_INV,0,ALN64I"@@targethost@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1024,		T_INV,0,ALN64I"@@d_atolf@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1101,		T_INV,0,ALN64I"@@installprefix@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1028,			T_INV,0,ALN64I"@@d_log2@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1031,		T_INV,0,ALN64I"@@installprefix@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1032,			T_INV,0,ALN64I"@@uuname@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1034,	T_INV,0,ALN64I"@@ctermid_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1106,			T_INV,0,ALN64I"@@uuname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1110,			T_INV,0,ALN64I"@@d_bcmp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1116,		T_INV,0,ALN64I"@@i_sysndir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1117,		T_INV,0,ALN64I"@@d_index@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1120,		T_INV,0,ALN64I"@@d_tgamma@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1123,		T_INV,0,ALN64I"@@intsize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1039,		T_INV,0,ALN64I"@@nm_so_opt@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1125,		T_INV,0,ALN64I"@@usesfio@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1041,		T_INV,0,ALN64I"@@i_ieeefp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1043,		T_INV,0,ALN64I"@@d_setgrps@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1044,			T_INV,0,ALN64I"@@bin@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1046,		T_INV,0,ALN64I"@@i_fp_class@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1047,		T_INV,0,ALN64I"@@d_fp_class@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1049,			T_INV,0,ALN64I"@@grep@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1050,			T_INV,0,ALN64I"@@i_db@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1052,			T_INV,0,ALN64I"@@egrep@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1053,			T_INV,0,ALN64I"@@d_bsd@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1054,			T_INV,0,ALN64I"@@i_grp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1057,		T_INV,0,ALN64I"@@bin_ELF@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1058,		T_INV,0,ALN64I"@@d_fp_classify@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1063,		T_INV,0,ALN64I"@@d_isfinite@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1064,		T_INV,0,ALN64I"@@d_tgamma@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1068,		T_INV,0,ALN64I"@@d_gmtime64@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1071,		T_INV,0,ALN64I"@@PERL_CONFIG_SH@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1076,		T_INV,0,ALN64I"@@d_fd_set@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1078,		T_INV,0,ALN64I"@@i_stddef@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1081,			T_INV,0,ALN64I"@@pager@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1083,		T_INV,0,ALN64I"@@i_sysndir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1084,		T_INV,0,ALN64I"@@d_index@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1089,		T_INV,0,ALN64I"@@d_msgsnd@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1090,		T_INV,0,ALN64I"@@d_getmnt@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1099,			T_INV,0,ALN64I"@@tbl@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1102,			T_INV,0,ALN64I"@@libs@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1103,		T_INV,0,ALN64I"@@full_ar@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1106,		T_INV,0,ALN64I"@@d_fp_classl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1111,		T_INV,0,ALN64I"@@d_fds_bits@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1115,		T_INV,0,ALN64I"@@i_utime@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1117,		T_INV,0,ALN64I"@@libsdirs@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1119,		T_INV,0,ALN64I"@@d_lgamma@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1122,		T_INV,0,ALN64I"@@d_isfinitel@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1123,		T_INV,0,ALN64I"@@d_finitel@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1124,		T_INV,0,ALN64I"@@RCSfile@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1129,		T_INV,0,ALN64I"@@d_ilogb@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1132,			T_INV,0,ALN64I"@@bison@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1133,		T_INV,0,ALN64I"@@i_float@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1135,		T_INV,0,ALN64I"@@d_procselfexe@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1138,		T_INV,0,ALN64I"@@d_memmem@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1141,		T_INV,0,ALN64I"@@sitebin@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1142,		T_INV,0,ALN64I"@@d_uname@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1145,		T_INV,0,ALN64I"@@usesfio@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1149,		T_INV,0,ALN64I"@@d_cmsghdr_s@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1134,			T_INV,0,ALN64I"@@yacc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1135,		T_INV,0,ALN64I"@@longsize@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1137,		T_INV,0,ALN64I"@@d_setpent@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1154,		T_INV,0,ALN64I"@@d_setpent@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1140,		T_INV,0,ALN64I"@@d_endpent@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1157,		T_INV,0,ALN64I"@@d_endpent@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1148,		T_INV,0,ALN64I"@@d_gmtime64@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1161,		T_INV,0,ALN64I"@@i_sysin@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1149,		T_INV,0,ALN64I"@@i64size@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1162,			T_INV,0,ALN64I"@@ranlib@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1150,		T_INV,0,ALN64I"@@d_atolf@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1163,		T_INV,0,ALN64I"@@d_readdir64_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1153,		T_INV,0,ALN64I"@@d_lroundl@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1168,			T_INV,0,ALN64I"@@nroff@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1155,		T_INV,0,ALN64I"@@d_accessx@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1157,		T_INV,0,ALN64I"@@d_pause@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1169,			T_INV,0,ALN64I"@@troff@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1164,		T_INV,0,ALN64I"@@d_procselfexe@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1176,		T_INV,0,ALN64I"@@d_pause@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1166,	T_INV,0,ALN64I"@@usecrosscompile@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1178,		T_INV,0,ALN64I"@@d_PRIEUldbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1179,		T_INV,0,ALN64I"@@d_flockproto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1180,		T_INV,0,ALN64I"@@d_PRIGUldbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1181,		T_INV,0,ALN64I"@@afsroot@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1169,		T_INV,0,ALN64I"@@d_PRIgldbl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1184,		T_INV,0,ALN64I"@@seedfunc@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1175,		T_INV,0,ALN64I"@@i16size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1185,		T_INV,0,ALN64I"@@d_PRIFUldbl@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1179,		T_INV,0,ALN64I"@@i_stddef@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1180,		T_INV,0,ALN64I"@@d_fd_set@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1188,		T_INV,0,ALN64I"@@d_ilogbl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1189,		T_INV,0,ALN64I"@@libperl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1197,		T_INV,0,ALN64I"@@d_regcmp@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1192,		T_INV,0,ALN64I"@@d_lgamma@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1200,			T_INV,0,ALN64I"@@i_dbm@@"},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1193,		T_INV,0,ALN64I"@@full_ar@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1202,		T_INV,0,ALN64I"@@d_PRIgldbl@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1205,		T_INV,0,ALN64I"@@d_ilogbl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1203,			T_INV,0,ALN64I"@@i_ndbm@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1204,			T_INV,0,ALN64I"@@d_ndbm@@"},
+      {XSCNO},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1206,		T_INV,0,ALN64I"@@d_usleep@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1219,			T_INV,0,ALN64I"@@i8type@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1212,			T_INV,0,ALN64I"@@d_cbrt@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1220,		T_INV,0,ALN64I"@@d_ftime@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1228,		T_INV,0,ALN64I"@@d_msync@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1222,		T_INV,0,ALN64I"@@d_modfl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1231,		T_INV,0,ALN64I"@@d_modflproto@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1226,		T_INV,0,ALN64I"@@seedfunc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1235,		T_INV,0,ALN64I"@@d_sysernlst@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1236,		T_INV,0,ALN64I"@@d_isfinite@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1237,		T_INV,0,ALN64I"@@i_utime@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1236,			T_INV,0,ALN64I"@@libc@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1239,		T_INV,0,ALN64I"@@RCSfile@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1238,		T_INV,0,ALN64I"@@randfunc@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1240,		T_INV,0,ALN64I"@@ptrsize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1239,	T_INV,0,ALN64I"@@d_msg_dontroute@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1241,		T_INV,0,ALN64I"@@d_dirnamlen@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1243,		T_INV,0,ALN64I"@@i_inttypes@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1244,			T_INV,0,ALN64I"@@d_log2@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1245,		T_INV,0,ALN64I"@@d_finitel@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1255,		T_INV,0,ALN64I"@@randbits@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1256,		T_INV,0,ALN64I"@@i32size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1262,		T_INV,0,ALN64I"@@d_uname@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1264,		T_INV,0,ALN64I"@@d_msgsnd@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1265,		T_INV,0,ALN64I"@@d_getmnt@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1266,		T_INV,0,ALN64I"@@randfunc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1267,	T_INV,0,ALN64I"@@PERL_API_VERSION@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1268,	T_INV,0,ALN64I"@@PERL_API_REVISION@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1272,		T_INV,0,ALN64I"@@d_mblen@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1273,	T_INV,0,ALN64I"@@PERL_API_SUBVERSION@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1274,		T_INV,0,ALN64I"@@sig_num@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1280,		T_INV,0,ALN64I"@@d_flockproto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1281,		T_INV,0,ALN64I"@@d_isnormal@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1290,		T_INV,0,ALN64I"@@d_signbit@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1247,			T_INV,0,ALN64I"@@sysman@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1304,		T_INV,0,ALN64I"@@sitelibexp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1305,		T_INV,0,ALN64I"@@d_getitimer@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1309,		T_INV,0,ALN64I"@@i_sysin@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1312,		T_INV,0,ALN64I"@@d_isfinitel@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1252,		T_INV,0,ALN64I"@@d_inetaton@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1314,		T_INV,0,ALN64I"@@i_stdbool@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1254,		T_INV,0,ALN64I"@@d_getprior@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1259,		T_INV,0,ALN64I"@@d_syserrlst@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1261,		T_INV,0,ALN64I"@@sPRIeldbl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1269,			T_INV,0,ALN64I"@@rm_try@@"},
       {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1272,		T_INV,0,ALN64I"@@sig_num@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1280,			T_INV,0,ALN64I"@@inews@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1306,			T_INV,0,ALN64I"@@i8type@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1315,		T_INV,0,ALN64I"@@d_getitimer@@"},
+      {XSCNO},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1317,		T_INV,0,ALN64I"@@d_suidsafe@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1321,		T_INV,0,ALN64I"@@i_float@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1321,		T_INV,0,ALN64I"@@d_wait4@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1325,		T_INV,0,ALN64I"@@d_msync@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1322,			T_INV,0,ALN64I"@@ebcdic@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1326,			T_INV,0,ALN64I"@@sh@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1341,		T_INV,0,ALN64I"@@i_sysmman@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1328,	T_INV,0,ALN64I"@@readdir64_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1343,		T_INV,0,ALN64I"@@d_mblen@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1332,		T_INV,0,ALN64I"@@d_sysernlst@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1344,		T_INV,0,ALN64I"@@d_readv@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1350,		T_INV,0,ALN64I"@@cf_time@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1334,			T_INV,0,ALN64I"@@csh@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1352,		T_INV,0,ALN64I"@@d_isnormal@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1336,			T_INV,0,ALN64I"@@hint@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1360,		T_INV,0,ALN64I"@@uidsign@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1361,	T_INV,0,ALN64I"@@readdir64_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1362,			T_INV,0,ALN64I"@@yacc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1372,		T_INV,0,ALN64I"@@d_setgrent_r@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1339,			T_INV,0,ALN64I"@@sysman@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1375,		T_INV,0,ALN64I"@@d_endgrent_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1376,			T_INV,0,ALN64I"@@sh@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1380,		T_INV,0,ALN64I"@@d_accessx@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1386,			T_INV,0,ALN64I"@@hint@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1392,		T_INV,0,ALN64I"@@d_dirnamlen@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1402,		T_INV,0,ALN64I"@@d_sendmsg@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1403,		T_INV,0,ALN64I"@@d_setegid@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1405,		T_INV,0,ALN64I"@@d_msg_oob@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1406,		T_INV,0,ALN64I"@@git_ancestor@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1416,		T_INV,0,ALN64I"@@d_signbit@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1427,		T_INV,0,ALN64I"@@d_setrgid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1435,			T_INV,0,ALN64I"@@shar@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1342,			T_INV,0,ALN64I"@@rm_try@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1438,		T_INV,0,ALN64I"@@d_rewinddir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1445,		T_INV,0,ALN64I"@@madlysrc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1449,		T_INV,0,ALN64I"@@d_fdclose@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1453,		T_INV,0,ALN64I"@@sitearch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1457,		T_INV,0,ALN64I"@@i_memory@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1460,		T_INV,0,ALN64I"@@sitelibexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1465,		T_INV,0,ALN64I"@@libperl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1466,			T_INV,0,ALN64I"@@i_pwd@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1470,		T_INV,0,ALN64I"@@man3direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1475,		T_INV,0,ALN64I"@@man1direxp@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1344,		T_INV,0,ALN64I"@@d_syserrlst@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1477,		T_INV,0,ALN64I"@@i_stdbool@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1346,			T_INV,0,ALN64I"@@d_csh@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1479,		T_INV,0,ALN64I"@@plibpth@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1496,		T_INV,0,ALN64I"@@d_setlocale@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1355,		T_INV,0,ALN64I"@@d_sendmsg@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1505,		T_INV,0,ALN64I"@@d_difftime@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1356,		T_INV,0,ALN64I"@@d_setegid@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1509,		T_INV,0,ALN64I"@@stdio_bufsiz@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1512,			T_INV,0,ALN64I"@@csh@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1513,	T_INV,0,ALN64I"@@stdio_stream_array@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1514,		T_INV,0,ALN64I"@@d_Gconvert@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1358,			T_INV,0,ALN64I"@@i_bfd@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1516,			T_INV,0,ALN64I"@@d_bcmp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1359,		T_INV,0,ALN64I"@@ld_can_script@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1520,		T_INV,0,ALN64I"@@ldflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1521,			T_INV,0,ALN64I"@@d_csh@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1525,		T_INV,0,ALN64I"@@d_fstatfs@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1528,		T_INV,0,ALN64I"@@d_semget@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1529,		T_INV,0,ALN64I"@@uidformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1533,		T_INV,0,ALN64I"@@randbits@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1534,		T_INV,0,ALN64I"@@d_chsize@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1535,			T_INV,0,ALN64I"@@d_shm@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1536,	T_INV,0,ALN64I"@@d_inc_version_list@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1538,		T_INV,0,ALN64I"@@d_difftime64@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1364,		T_INV,0,ALN64I"@@d_fdclose@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1368,		T_INV,0,ALN64I"@@d_setrgid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1369,			T_INV,0,ALN64I"@@nroff@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1370,			T_INV,0,ALN64I"@@troff@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1371,			T_INV,0,ALN64I"@@shar@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1372,		T_INV,0,ALN64I"@@d_chsize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1376,		T_INV,0,ALN64I"@@stdchar@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1377,		T_INV,0,ALN64I"@@i_sgtty@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1380,		T_INV,0,ALN64I"@@d_msg_oob@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1385,		T_INV,0,ALN64I"@@d_ftime@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1387,		T_INV,0,ALN64I"@@cf_time@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1389,		T_INV,0,ALN64I"@@sitearch@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1392,		T_INV,0,ALN64I"@@d_cplusplus@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1394,	T_INV,0,ALN64I"@@d_prctl_set_name@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1405,		T_INV,0,ALN64I"@@charsize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1412,		T_INV,0,ALN64I"@@i_bsdioctl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1416,		T_INV,0,ALN64I"@@archname@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1419,			T_INV,0,ALN64I"@@submit@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1426,		T_INV,0,ALN64I"@@madlysrc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1432,		T_INV,0,ALN64I"@@d_fpathconf@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1433,		T_INV,0,ALN64I"@@i_sunmath@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1435,		T_INV,0,ALN64I"@@d_bzero@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1437,		T_INV,0,ALN64I"@@netdb_net_type@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1443,		T_INV,0,ALN64I"@@useopcode@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1446,		T_INV,0,ALN64I"@@d_memmem@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1452,		T_INV,0,ALN64I"@@afsroot@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1454,			T_INV,0,ALN64I"@@incpth@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1463,		T_INV,0,ALN64I"@@d_setpgid@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1466,		T_INV,0,ALN64I"@@archlib@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1468,	T_INV,0,ALN64I"@@userelocatableinc@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1471,			T_INV,0,ALN64I"@@gzip@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1473,		T_INV,0,ALN64I"@@man3direxp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1474,		T_INV,0,ALN64I"@@uidsign@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1484,		T_INV,0,ALN64I"@@d_uselocale@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1543,		T_INV,0,ALN64I"@@i_syssockio@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1492,		T_INV,0,ALN64I"@@d_setgrent_r@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1551,		T_INV,0,ALN64I"@@useopcode@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1495,		T_INV,0,ALN64I"@@d_endgrent_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1556,		T_INV,0,ALN64I"@@stdchar@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1496,		T_INV,0,ALN64I"@@archname64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1497,		T_INV,0,ALN64I"@@stdio_bufsiz@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1505,		T_INV,0,ALN64I"@@i_syssockio@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1507,		T_INV,0,ALN64I"@@man1direxp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1508,	T_INV,0,ALN64I"@@d_msg_dontroute@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1510,		T_INV,0,ALN64I"@@doublesize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1521,		T_INV,0,ALN64I"@@git_ancestor@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1561,	T_INV,0,ALN64I"@@asctime_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1528,		T_INV,0,ALN64I"@@ccflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1536,			T_INV,0,ALN64I"@@echo@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1550,		T_INV,0,ALN64I"@@uidsize@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1551,		T_INV,0,ALN64I"@@i_sysmman@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1552,			T_INV,0,ALN64I"@@d_shm@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1553,		T_INV,0,ALN64I"@@d_fpclass@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1554,		T_INV,0,ALN64I"@@d_modflproto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1555,		T_INV,0,ALN64I"@@mips_type@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1556,	T_INV,0,ALN64I"@@stdio_stream_array@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1567,		T_INV,0,ALN64I"@@d_msgctl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1572,		T_INV,0,ALN64I"@@u64size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1583,			T_INV,0,ALN64I"@@i_math@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1584,		T_INV,0,ALN64I"@@d_castneg@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1594,		T_INV,0,ALN64I"@@ldflags@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1595,		T_INV,0,ALN64I"@@d_duplocale@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1596,	T_INV,0,ALN64I"@@asctime_r_proto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1598,		T_INV,0,ALN64I"@@u16size@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1568,			T_INV,0,ALN64I"@@i_math@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1604,		T_INV,0,ALN64I"@@d_random_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1612,		T_INV,0,ALN64I"@@d_difftime@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1613,		T_INV,0,ALN64I"@@i_syspoll@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1616,		T_INV,0,ALN64I"@@d_archlib@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1617,		T_INV,0,ALN64I"@@i_machcthr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1626,		T_INV,0,ALN64I"@@d_bcopy@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1629,		T_INV,0,ALN64I"@@d_fpclassl@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1630,		T_INV,0,ALN64I"@@d_fstatfs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1637,		T_INV,0,ALN64I"@@d_semget@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1642,			T_INV,0,ALN64I"@@u8type@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1574,		T_INV,0,ALN64I"@@d_cplusplus@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1644,		T_INV,0,ALN64I"@@sSCNfldbl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1576,			T_INV,0,ALN64I"@@i_bfd@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1577,		T_INV,0,ALN64I"@@d_setproctitle@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1578,		T_INV,0,ALN64I"@@i_sysun@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1582,		T_INV,0,ALN64I"@@d_off64_t@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1584,		T_INV,0,ALN64I"@@charsize@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1585,		T_INV,0,ALN64I"@@d_setpgid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1596,		T_INV,0,ALN64I"@@netdb_net_type@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1599,			T_INV,0,ALN64I"@@echo@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1603,		T_INV,0,ALN64I"@@full_sed@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1604,		T_INV,0,ALN64I"@@d_fsync@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1650,		T_INV,0,ALN64I"@@libsfiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1610,		T_INV,0,ALN64I"@@archname@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1660,		T_INV,0,ALN64I"@@i_crypt@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1611,		T_INV,0,ALN64I"@@d_fpathconf@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1661,		T_INV,0,ALN64I"@@d_crypt@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1662,		T_INV,0,ALN64I"@@sPRIfldbl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1666,	T_INV,0,ALN64I"@@d_lc_monetary_2008@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1669,		T_INV,0,ALN64I"@@d_crypt_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1674,		T_INV,0,ALN64I"@@d_chroot@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1676,		T_INV,0,ALN64I"@@d_stdiobase@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1679,		T_INV,0,ALN64I"@@u32size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1685,		T_INV,0,ALN64I"@@d_difftime64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1686,		T_INV,0,ALN64I"@@d_fsync@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1690,		T_INV,0,ALN64I"@@d_sresgproto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1691,		T_INV,0,ALN64I"@@uidformat@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1694,		T_INV,0,ALN64I"@@i_syssecrt@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1705,		T_INV,0,ALN64I"@@i_sysresrc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1706,		T_INV,0,ALN64I"@@d_isblank@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1612,		T_INV,0,ALN64I"@@d_msgctl@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1722,		T_INV,0,ALN64I"@@hostperl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1619,			T_INV,0,ALN64I"@@submit@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1726,		T_INV,0,ALN64I"@@i_sysaccess@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1730,		T_INV,0,ALN64I"@@i_sysioctl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1732,		T_INV,0,ALN64I"@@i_sysun@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1733,		T_INV,0,ALN64I"@@i_memory@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1623,		T_INV,0,ALN64I"@@d_getmntent@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1736,		T_INV,0,ALN64I"@@d_malloc_size@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1626,		T_INV,0,ALN64I"@@d_htonl@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1629,		T_INV,0,ALN64I"@@doublesize@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1630,		T_INV,0,ALN64I"@@i_sunmath@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1640,	T_INV,0,ALN64I"@@d_lc_monetary_2008@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1644,		T_INV,0,ALN64I"@@d_tm_tm_zone@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1645,		T_INV,0,ALN64I"@@d_dlsymun@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1646,		T_INV,0,ALN64I"@@d_castneg@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1649,		T_INV,0,ALN64I"@@i_syspoll@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1660,		T_INV,0,ALN64I"@@d_pseudofork@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1667,		T_INV,0,ALN64I"@@i_sysselct@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1670,		T_INV,0,ALN64I"@@archname64@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1744,		T_INV,0,ALN64I"@@full_sed@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1747,		T_INV,0,ALN64I"@@d_munmap@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1749,		T_INV,0,ALN64I"@@prototype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1753,			T_INV,0,ALN64I"@@chmod@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1678,		T_INV,0,ALN64I"@@hostosname@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1758,		T_INV,0,ALN64I"@@d_htonl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1683,		T_INV,0,ALN64I"@@sysroot@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1759,		T_INV,0,ALN64I"@@ssizetype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1695,		T_INV,0,ALN64I"@@d_timegm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1766,		T_INV,0,ALN64I"@@i_sysselct@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1707,			T_INV,0,ALN64I"@@incpth@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1715,		T_INV,0,ALN64I"@@hostperl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1721,		T_INV,0,ALN64I"@@d_sresgproto@@"},
       {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1723,			T_INV,0,ALN64I"@@u8type@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1727,		T_INV,0,ALN64I"@@ccflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1738,		T_INV,0,ALN64I"@@d_wcscmp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1740,		T_INV,0,ALN64I"@@i_syssecrt@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1742,		T_INV,0,ALN64I"@@i_machcthr@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1747,	T_INV,0,ALN64I"@@d_prctl_set_name@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1751,		T_INV,0,ALN64I"@@d_system@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1752,			T_INV,0,ALN64I"@@chmod@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1763,		T_INV,0,ALN64I"@@i_sysresrc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
       {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1768,		T_INV,0,ALN64I"@@doublekind@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1773,		T_INV,0,ALN64I"@@rd_nodata@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1769,		T_INV,0,ALN64I"@@archlib@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1772,		T_INV,0,ALN64I"@@gidsign@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1775,	T_INV,0,ALN64I"@@d_stdio_stream_array@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1774,		T_INV,0,ALN64I"@@i_sysaccess@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1776,		T_INV,0,ALN64I"@@d_timegm@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1779,		T_INV,0,ALN64I"@@d_getgrent@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1783,		T_INV,0,ALN64I"@@sSCNfldbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1784,		T_INV,0,ALN64I"@@sPRIfldbl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1788,	T_INV,0,ALN64I"@@d_siginfo_si_addr@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1790,		T_INV,0,ALN64I"@@libsfiles@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1789,		T_INV,0,ALN64I"@@d_getgrps@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1803,		T_INV,0,ALN64I"@@d_getsent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1804,		T_INV,0,ALN64I"@@d_getnent@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1792,		T_INV,0,ALN64I"@@d_fd_macros@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1807,		T_INV,0,ALN64I"@@aphostname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1793,		T_INV,0,ALN64I"@@glibpth@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1815,		T_INV,0,ALN64I"@@i16type@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1795,		T_INV,0,ALN64I"@@d_tm_tm_zone@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1817,		T_INV,0,ALN64I"@@i64type@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1821,		T_INV,0,ALN64I"@@d_chroot@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1833,	T_INV,0,ALN64I"@@PERL_API_VERSION@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1836,		T_INV,0,ALN64I"@@i_crypt@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1837,		T_INV,0,ALN64I"@@d_crypt@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1838,	T_INV,0,ALN64I"@@PERL_API_REVISION@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1840,		T_INV,0,ALN64I"@@d_getfsstat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1841,	T_INV,0,ALN64I"@@PERL_API_SUBVERSION@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1842,		T_INV,0,ALN64I"@@d_crypt_r@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1844,		T_INV,0,ALN64I"@@i32type@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1848,		T_INV,0,ALN64I"@@d_statvfs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1854,		T_INV,0,ALN64I"@@usereentrant@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1859,		T_INV,0,ALN64I"@@i_bsdioctl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1863,	T_INV,0,ALN64I"@@d_siginfo_si_errno@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1865,	T_INV,0,ALN64I"@@d_stdio_stream_array@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1869,		T_INV,0,ALN64I"@@d_archlib@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1871,		T_INV,0,ALN64I"@@usefaststdio@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1875,		T_INV,0,ALN64I"@@d_getgrps@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1877,		T_INV,0,ALN64I"@@i_sysioctl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1881,		T_INV,0,ALN64I"@@d_locconv@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1805,		T_INV,0,ALN64I"@@d_pseudofork@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1807,		T_INV,0,ALN64I"@@usedtrace@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1808,	T_INV,0,ALN64I"@@strerror_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1891,		T_INV,0,ALN64I"@@d_wcstombs@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1815,		T_INV,0,ALN64I"@@i64type@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1898,		T_INV,0,ALN64I"@@found_libucb@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1816,		T_INV,0,ALN64I"@@d_dlsymun@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1903,		T_INV,0,ALN64I"@@siteman3direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1824,			T_INV,0,ALN64I"@@i_gdbm@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1908,		T_INV,0,ALN64I"@@siteman1direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1913,	T_INV,0,ALN64I"@@d_siginfo_si_pid@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1914,		T_INV,0,ALN64I"@@d_uselocale@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1915,			T_INV,0,ALN64I"@@Author@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1917,		T_INV,0,ALN64I"@@i_sysmount@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1827,		T_INV,0,ALN64I"@@d_setlocale_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1828,	T_INV,0,ALN64I"@@installusrbinperl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1833,		T_INV,0,ALN64I"@@d_dir_dd_fd@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1841,		T_INV,0,ALN64I"@@i16type@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1847,		T_INV,0,ALN64I"@@d_getmntent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1848,		T_INV,0,ALN64I"@@d_setsid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1849,		T_INV,0,ALN64I"@@d_off64_t@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1854,		T_INV,0,ALN64I"@@d_getsent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1855,		T_INV,0,ALN64I"@@d_getnent@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1859,			T_INV,0,ALN64I"@@d_j0@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1865,	T_INV,0,ALN64I"@@old_pthread_create_joinable@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1873,		T_INV,0,ALN64I"@@gidsign@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1879,	T_INV,0,ALN64I"@@d_siginfo_si_addr@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1880,		T_INV,0,ALN64I"@@sitehtml3dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1881,		T_INV,0,ALN64I"@@d_isascii@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1882,			T_INV,0,ALN64I"@@d_logb@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1883,		T_INV,0,ALN64I"@@d_getgrent@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1885,		T_INV,0,ALN64I"@@found_libucb@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1889,		T_INV,0,ALN64I"@@d_getfsstat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1897,		T_INV,0,ALN64I"@@d_system@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1898,		T_INV,0,ALN64I"@@pidtype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1899,		T_INV,0,ALN64I"@@d_casti32@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1900,			T_INV,0,ALN64I"@@byacc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1908,		T_INV,0,ALN64I"@@aphostname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1914,		T_INV,0,ALN64I"@@sPRIgldbl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1922,		T_INV,0,ALN64I"@@i32type@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1924,		T_INV,0,ALN64I"@@usefaststdio@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1929,		T_INV,0,ALN64I"@@siteman3direxp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1933,		T_INV,0,ALN64I"@@i_libutil@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1935,			T_INV,0,ALN64I"@@d_j0l@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1937,		T_INV,0,ALN64I"@@sysroot@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1943,	T_INV,0,ALN64I"@@d_siginfo_si_pid@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1948,		T_INV,0,ALN64I"@@d_setresgid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1949,		T_INV,0,ALN64I"@@gidsize@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1952,		T_INV,0,ALN64I"@@d_setnetent_r@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1955,		T_INV,0,ALN64I"@@d_endnetent_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1957,		T_INV,0,ALN64I"@@cppsymbols@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1962,		T_INV,0,ALN64I"@@d_getpent@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1963,		T_INV,0,ALN64I"@@siteman1direxp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1964,	T_INV,0,ALN64I"@@d_builtin_expect@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1965,			T_INV,0,ALN64I"@@touch@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1966,		T_INV,0,ALN64I"@@d_mymalloc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1968,	T_INV,0,ALN64I"@@perl_static_inline@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1971,		T_INV,0,ALN64I"@@hostosname@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1974,			T_INV,0,ALN64I"@@Author@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1979,		T_INV,0,ALN64I"@@d_dbminitproto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1920,		T_INV,0,ALN64I"@@sitehtml3dir@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1986,		T_INV,0,ALN64I"@@d_shmdt@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1927,		T_INV,0,ALN64I"@@sitehtml1dir@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1988,		T_INV,0,ALN64I"@@sitehtml1dir@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1991,		T_INV,0,ALN64I"@@i_sysstat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1996,			T_INV,0,ALN64I"@@inews@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1997,		T_INV,0,ALN64I"@@hostcat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2008,		T_INV,0,ALN64I"@@i_sysmode@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2010,		T_INV,0,ALN64I"@@d_shmat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2011,		T_INV,0,ALN64I"@@d_hasmntopt@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2016,		T_INV,0,ALN64I"@@d_tcsetpgrp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2049,		T_INV,0,ALN64I"@@d_readv@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2052,		T_INV,0,ALN64I"@@d_sysconf@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2054,			T_INV,0,ALN64I"@@vi@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2059,	T_INV,0,ALN64I"@@d_siginfo_si_errno@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2060,		T_INV,0,ALN64I"@@i_sysmount@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2061,		T_INV,0,ALN64I"@@d_semctl_semun@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2062,		T_INV,0,ALN64I"@@cppstdin@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2064,		T_INV,0,ALN64I"@@d_shmctl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2072,		T_INV,0,ALN64I"@@i_pthread@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2073,		T_INV,0,ALN64I"@@d_wait4@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2078,	T_INV,0,ALN64I"@@d_semctl_semid_ds@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2079,		T_INV,0,ALN64I"@@d_msg_ctrunc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2081,		T_INV,0,ALN64I"@@d_seteuid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2082,		T_INV,0,ALN64I"@@d_statfs_s@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2085,		T_INV,0,ALN64I"@@byteorder@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2090,		T_INV,0,ALN64I"@@gidformat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2091,		T_INV,0,ALN64I"@@d_portable@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2093,		T_INV,0,ALN64I"@@d_setruid@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2096,		T_INV,0,ALN64I"@@perlpath@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2097,		T_INV,0,ALN64I"@@d_sched_yield@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2102,		T_INV,0,ALN64I"@@d_longdbl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2110,			T_INV,0,ALN64I"@@i_pwd@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2116,		T_INV,0,ALN64I"@@i_syslog@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2117,		T_INV,0,ALN64I"@@d_remainder@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2120,		T_INV,0,ALN64I"@@sitescript@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2122,			T_INV,0,ALN64I"@@bash@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1929,		T_INV,0,ALN64I"@@d_mymalloc@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2126,		T_INV,0,ALN64I"@@d_wcscmp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2134,		T_INV,0,ALN64I"@@h_fcntl@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2136,		T_INV,0,ALN64I"@@d_fpclassify@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2137,		T_INV,0,ALN64I"@@d_sitearch@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2138,	T_INV,0,ALN64I"@@d_inc_version_list@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1933,			T_INV,0,ALN64I"@@d_j0@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2142,		T_INV,0,ALN64I"@@sitescriptexp@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1937,		T_INV,0,ALN64I"@@i_sysmode@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2145,		T_INV,0,ALN64I"@@d_fs_data_s@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1941,		T_INV,0,ALN64I"@@gidformat@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2146,		T_INV,0,ALN64I"@@signal_t@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1942,		T_INV,0,ALN64I"@@d_setsid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1948,		T_INV,0,ALN64I"@@i_sysstat@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2153,		T_INV,0,ALN64I"@@sendmail@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1955,		T_INV,0,ALN64I"@@d_munmap@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1956,		T_INV,0,ALN64I"@@d_fd_macros@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1957,		T_INV,0,ALN64I"@@d_fpclass@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1958,		T_INV,0,ALN64I"@@d_setresgid@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2156,		T_INV,0,ALN64I"@@d_u32align@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2161,		T_INV,0,ALN64I"@@path_sep@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1961,		T_INV,0,ALN64I"@@d_msg_ctrunc@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2163,		T_INV,0,ALN64I"@@sig_name_init@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2164,	T_INV,0,ALN64I"@@pthread_h_first@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2168,		T_INV,0,ALN64I"@@d_syscall@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2169,		T_INV,0,ALN64I"@@installsitebin@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1963,		T_INV,0,ALN64I"@@d_shmdt@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2172,		T_INV,0,ALN64I"@@installman3dir@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1966,		T_INV,0,ALN64I"@@sizesize@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2173,		T_INV,0,ALN64I"@@ccstdflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2179,		T_INV,0,ALN64I"@@Revision@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2183,		T_INV,0,ALN64I"@@d_fpos64_t@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2187,		T_INV,0,ALN64I"@@sitebinexp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2192,		T_INV,0,ALN64I"@@revision@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2198,		T_INV,0,ALN64I"@@d_dbl_dig@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1969,		T_INV,0,ALN64I"@@pidtype@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2206,		T_INV,0,ALN64I"@@installman1dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2211,		T_INV,0,ALN64I"@@targetsh@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1977,		T_INV,0,ALN64I"@@d_isascii@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2214,		T_INV,0,ALN64I"@@d_vendorbin@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1980,			T_INV,0,ALN64I"@@vi@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2216,		T_INV,0,ALN64I"@@uidtype@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1986,		T_INV,0,ALN64I"@@d_getpent@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2218,		T_INV,0,ALN64I"@@d_Gconvert@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1989,		T_INV,0,ALN64I"@@d_shmat@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1992,			T_INV,0,ALN64I"@@d_j0l@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1995,		T_INV,0,ALN64I"@@d_tzname@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2227,		T_INV,0,ALN64I"@@d_seekdir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2229,		T_INV,0,ALN64I"@@d_inetpton@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2004,		T_INV,0,ALN64I"@@d_seteuid@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2232,		T_INV,0,ALN64I"@@d_strtoq@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2234,	T_INV,0,ALN64I"@@setnetent_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2235,		T_INV,0,ALN64I"@@cppflags@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2237,	T_INV,0,ALN64I"@@endnetent_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2238,		T_INV,0,ALN64I"@@u64type@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2248,		T_INV,0,ALN64I"@@d_rewinddir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2249,		T_INV,0,ALN64I"@@d_fchmod@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2251,		T_INV,0,ALN64I"@@cccdlflags@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2253,		T_INV,0,ALN64I"@@i_gdbmndbm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2261,	T_INV,0,ALN64I"@@d_siginfo_si_uid@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2263,			T_INV,0,ALN64I"@@mv@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2264,		T_INV,0,ALN64I"@@u16type@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2267,		T_INV,0,ALN64I"@@i_termio@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2268,		T_INV,0,ALN64I"@@privlib@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2271,		T_INV,0,ALN64I"@@i_termios@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2272,			T_INV,0,ALN64I"@@osvers@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2276,		T_INV,0,ALN64I"@@ccsymbols@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2280,		T_INV,0,ALN64I"@@d_nl_langinfo@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2282,		T_INV,0,ALN64I"@@d_gmtime_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2284,			T_INV,0,ALN64I"@@chgrp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2285,			T_INV,0,ALN64I"@@libpth@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2288,		T_INV,0,ALN64I"@@d_getpgid@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2291,	T_INV,0,ALN64I"@@d_siginfo_si_status@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2292,		T_INV,0,ALN64I"@@castflags@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2293,			T_INV,0,ALN64I"@@d_link@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2306,		T_INV,0,ALN64I"@@d_vendorscript@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2312,		T_INV,0,ALN64I"@@spitshell@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2314,	T_INV,0,ALN64I"@@installsiteman3dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2315,		T_INV,0,ALN64I"@@stdio_ptr@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2317,		T_INV,0,ALN64I"@@d_getgrent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2323,		T_INV,0,ALN64I"@@i_systypes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2007,			T_INV,0,ALN64I"@@i8size@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2332,		T_INV,0,ALN64I"@@d_sqrtl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2016,		T_INV,0,ALN64I"@@d_fpclassl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2336,		T_INV,0,ALN64I"@@d_setproctitle@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2343,		T_INV,0,ALN64I"@@d_wcstombs@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2022,			T_INV,0,ALN64I"@@touch@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2345,		T_INV,0,ALN64I"@@u32type@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2024,			T_INV,0,ALN64I"@@d_logb@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2346,		T_INV,0,ALN64I"@@ccdlflags@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2347,		T_INV,0,ALN64I"@@static_ext@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2348,	T_INV,0,ALN64I"@@installsiteman1dir@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2028,		T_INV,0,ALN64I"@@d_setruid@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2351,		T_INV,0,ALN64I"@@d_sethent@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2031,		T_INV,0,ALN64I"@@d_hasmntopt@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2354,		T_INV,0,ALN64I"@@d_endhent@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2359,		T_INV,0,ALN64I"@@groupcat@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2034,			T_INV,0,ALN64I"@@i_gdbm@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2370,		T_INV,0,ALN64I"@@eunicefix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2382,		T_INV,0,ALN64I"@@d_tm_tm_gmtoff@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2384,		T_INV,0,ALN64I"@@d_clearenv@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2386,		T_INV,0,ALN64I"@@usethreads@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2389,			T_INV,0,ALN64I"@@_exe@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2395,		T_INV,0,ALN64I"@@locincpth@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2401,		T_INV,0,ALN64I"@@d_locconv@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2403,	T_INV,0,ALN64I"@@d_siginfo_si_fd@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2406,		T_INV,0,ALN64I"@@d_lgamma_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2407,		T_INV,0,ALN64I"@@d_gethname@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2410,	T_INV,0,ALN64I"@@installhtml3dir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2412,		T_INV,0,ALN64I"@@lddlflags@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2415,		T_INV,0,ALN64I"@@d_sresuproto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2417,	T_INV,0,ALN64I"@@installhtml1dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2418,		T_INV,0,ALN64I"@@d_getnameinfo@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2423,		T_INV,0,ALN64I"@@i_socks@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2428,		T_INV,0,ALN64I"@@sockethdr@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2431,			T_INV,0,ALN64I"@@extras@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2432,			T_INV,0,ALN64I"@@Locker@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2435,		T_INV,0,ALN64I"@@d_llround@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2436,		T_INV,0,ALN64I"@@d_mkdir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2437,			T_INV,0,ALN64I"@@mkdir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2438,		T_INV,0,ALN64I"@@d_mktime@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2439,		T_INV,0,ALN64I"@@sGMTIME_max@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2443,			T_INV,0,ALN64I"@@cf_by@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2444,			T_INV,0,ALN64I"@@make@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2045,		T_INV,0,ALN64I"@@d_dbminitproto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2453,		T_INV,0,ALN64I"@@d_re_comp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2054,	T_INV,0,ALN64I"@@old_pthread_create_joinable@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2056,		T_INV,0,ALN64I"@@hostcat@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2457,		T_INV,0,ALN64I"@@sPRIx64@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2060,	T_INV,0,ALN64I"@@userelocatableinc@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2459,		T_INV,0,ALN64I"@@d_freelocale@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2461,		T_INV,0,ALN64I"@@d_msgget@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2463,		T_INV,0,ALN64I"@@d_pathconf@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2466,			T_INV,0,ALN64I"@@dlext@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2469,		T_INV,0,ALN64I"@@stdio_filbuf@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2474,		T_INV,0,ALN64I"@@d_dosuid@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2476,		T_INV,0,ALN64I"@@version@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2480,		T_INV,0,ALN64I"@@d_stdstdio@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2061,		T_INV,0,ALN64I"@@d_u32align@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2078,	T_INV,0,ALN64I"@@installusrbinperl@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2491,		T_INV,0,ALN64I"@@vendorbin@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2493,	T_INV,0,ALN64I"@@d_old_pthread_create_joinable@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2495,		T_INV,0,ALN64I"@@d_PRIx64@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2497,		T_INV,0,ALN64I"@@full_csh@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2501,		T_INV,0,ALN64I"@@cppminus@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2504,		T_INV,0,ALN64I"@@vendorlib@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2505,			T_INV,0,ALN64I"@@expr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2510,		T_INV,0,ALN64I"@@d_syscallproto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2511,		T_INV,0,ALN64I"@@d_llroundl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2517,		T_INV,0,ALN64I"@@d_semop@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2518,		T_INV,0,ALN64I"@@d_mktime64@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2519,		T_INV,0,ALN64I"@@vaproto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2521,			T_INV,0,ALN64I"@@uniq@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2080,		T_INV,0,ALN64I"@@ld_can_script@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2531,		T_INV,0,ALN64I"@@sLOCALTIME_max@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2534,	T_INV,0,ALN64I"@@d_getprotoprotos@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2090,		T_INV,0,ALN64I"@@cppsymbols@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2536,		T_INV,0,ALN64I"@@scriptdirexp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2537,		T_INV,0,ALN64I"@@d_tmpnam_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2092,		T_INV,0,ALN64I"@@sPRIgldbl@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2540,		T_INV,0,ALN64I"@@sched_yield@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2095,			T_INV,0,ALN64I"@@osvers@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2545,		T_INV,0,ALN64I"@@useithreads@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2100,		T_INV,0,ALN64I"@@d_duplocale@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2552,		T_INV,0,ALN64I"@@myuname@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2107,		T_INV,0,ALN64I"@@i_libutil@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2554,			T_INV,0,ALN64I"@@pmake@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2113,			T_INV,0,ALN64I"@@zcat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2558,	T_INV,0,ALN64I"@@d_getnetbyname_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2121,		T_INV,0,ALN64I"@@d_setnetent_r@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2561,			T_INV,0,ALN64I"@@d_quad@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2124,		T_INV,0,ALN64I"@@d_endnetent_r@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2562,		T_INV,0,ALN64I"@@d_longlong@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2563,		T_INV,0,ALN64I"@@doublemantbits@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2568,		T_INV,0,ALN64I"@@i_sysstatfs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2573,		T_INV,0,ALN64I"@@op_cflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2578,		T_INV,0,ALN64I"@@charbits@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2125,			T_INV,0,ALN64I"@@mv@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2581,		T_INV,0,ALN64I"@@ansi2knr@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2128,		T_INV,0,ALN64I"@@glibpth@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2131,			T_INV,0,ALN64I"@@zip@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2591,			T_INV,0,ALN64I"@@nvsize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2147,		T_INV,0,ALN64I"@@d_longlong@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2148,		T_INV,0,ALN64I"@@i_syslog@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2593,			T_INV,0,ALN64I"@@ivsize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2150,	T_INV,0,ALN64I"@@d_siginfo_si_uid@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2151,		T_INV,0,ALN64I"@@d_casti32@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2152,		T_INV,0,ALN64I"@@d_shmctl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2159,		T_INV,0,ALN64I"@@i_pthread@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2162,		T_INV,0,ALN64I"@@usedtrace@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2597,		T_INV,0,ALN64I"@@i_arpainet@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2166,		T_INV,0,ALN64I"@@stdio_ptr@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2171,		T_INV,0,ALN64I"@@sendmail@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2173,		T_INV,0,ALN64I"@@d_remainder@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2180,		T_INV,0,ALN64I"@@d_longdbl@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2181,		T_INV,0,ALN64I"@@Revision@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2182,	T_INV,0,ALN64I"@@d_siginfo_si_status@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2184,		T_INV,0,ALN64I"@@version@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2187,		T_INV,0,ALN64I"@@installsitebin@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2194,		T_INV,0,ALN64I"@@i_termio@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2196,		T_INV,0,ALN64I"@@h_fcntl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2198,		T_INV,0,ALN64I"@@i_termios@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2199,	T_INV,0,ALN64I"@@d_builtin_expect@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2204,		T_INV,0,ALN64I"@@d_getgrent_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2205,		T_INV,0,ALN64I"@@revision@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2206,		T_INV,0,ALN64I"@@uidtype@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2207,		T_INV,0,ALN64I"@@rd_nodata@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2209,		T_INV,0,ALN64I"@@d_isblank@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2211,		T_INV,0,ALN64I"@@usemallocwrap@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2215,	T_INV,0,ALN64I"@@setservent_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2217,		T_INV,0,ALN64I"@@sitescript@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2218,	T_INV,0,ALN64I"@@endservent_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2221,		T_INV,0,ALN64I"@@d_llround@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2222,		T_INV,0,ALN64I"@@byteorder@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2226,		T_INV,0,ALN64I"@@sitescriptexp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2229,		T_INV,0,ALN64I"@@d_sysconf@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2231,	T_INV,0,ALN64I"@@pthread_h_first@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2232,		T_INV,0,ALN64I"@@u16type@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2233,		T_INV,0,ALN64I"@@d_strlcpy@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2234,		T_INV,0,ALN64I"@@u64type@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2237,		T_INV,0,ALN64I"@@d_random_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2240,	T_INV,0,ALN64I"@@setnetent_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2243,	T_INV,0,ALN64I"@@endnetent_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2246,		T_INV,0,ALN64I"@@d_sqrtl@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2249,	T_INV,0,ALN64I"@@d_siginfo_si_fd@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2606,		T_INV,0,ALN64I"@@vendorman3dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2614,		T_INV,0,ALN64I"@@d_statvfs@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2615,		T_INV,0,ALN64I"@@gidtype@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2617,		T_INV,0,ALN64I"@@d_localtime64@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2627,	T_INV,0,ALN64I"@@d_siginfo_si_band@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2258,		T_INV,0,ALN64I"@@d_tm_tm_gmtoff@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2630,			T_INV,0,ALN64I"@@d_exp2@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2640,		T_INV,0,ALN64I"@@vendorman1dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2641,			T_INV,0,ALN64I"@@i_fenv@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2642,		T_INV,0,ALN64I"@@socketlib@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2650,	T_INV,0,ALN64I"@@setprotoent_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2653,	T_INV,0,ALN64I"@@endprotoent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2666,		T_INV,0,ALN64I"@@installarchlib@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2667,		T_INV,0,ALN64I"@@archlibexp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2673,		T_INV,0,ALN64I"@@d_setresuid@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2676,	T_INV,0,ALN64I"@@ttyname_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2677,		T_INV,0,ALN64I"@@usereentrant@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2683,		T_INV,0,ALN64I"@@d_readlink@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2684,		T_INV,0,ALN64I"@@i_stdlib@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2685,		T_INV,0,ALN64I"@@d_asctime_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2687,		T_INV,0,ALN64I"@@d_ttyname_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2688,	T_INV,0,ALN64I"@@setgrent_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2691,	T_INV,0,ALN64I"@@endgrent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2697,		T_INV,0,ALN64I"@@d_asctime64@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2702,			T_INV,0,ALN64I"@@mailx@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2714,		T_INV,0,ALN64I"@@d_closedir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2716,		T_INV,0,ALN64I"@@d_setpwent@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2719,		T_INV,0,ALN64I"@@d_endpwent@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2731,		T_INV,0,ALN64I"@@cf_email@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2738,			T_INV,0,ALN64I"@@madlyh@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2741,		T_INV,0,ALN64I"@@libspath@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2746,		T_INV,0,ALN64I"@@nvmantbits@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2261,		T_INV,0,ALN64I"@@u32type@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2755,		T_INV,0,ALN64I"@@d_copysign@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2270,		T_INV,0,ALN64I"@@d_inetpton@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2275,		T_INV,0,ALN64I"@@d_freelocale@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2280,		T_INV,0,ALN64I"@@d_llroundl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2282,		T_INV,0,ALN64I"@@targetsh@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2285,		T_INV,0,ALN64I"@@d_strtoq@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2287,		T_INV,0,ALN64I"@@perlpath@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2288,		T_INV,0,ALN64I"@@d_stdiobase@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2299,	T_INV,0,ALN64I"@@installhtml3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2304,		T_INV,0,ALN64I"@@d_semop@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2305,		T_INV,0,ALN64I"@@d_clearenv@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2307,		T_INV,0,ALN64I"@@spitshell@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2308,		T_INV,0,ALN64I"@@d_pathconf@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2309,	T_INV,0,ALN64I"@@strerror_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2311,		T_INV,0,ALN64I"@@path_sep@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2313,		T_INV,0,ALN64I"@@vendorman3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2318,		T_INV,0,ALN64I"@@vendorman1dir@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2777,		T_INV,0,ALN64I"@@d_getnetent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2322,		T_INV,0,ALN64I"@@d_sresuproto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2785,		T_INV,0,ALN64I"@@db_hashtype@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2326,	T_INV,0,ALN64I"@@installhtml1dir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2327,		T_INV,0,ALN64I"@@vendorbin@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2331,	T_INV,0,ALN64I"@@d_getprotoprotos@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2332,		T_INV,0,ALN64I"@@installman3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2337,		T_INV,0,ALN64I"@@installman1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2341,		T_INV,0,ALN64I"@@myuname@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2343,		T_INV,0,ALN64I"@@d_sethent@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2346,		T_INV,0,ALN64I"@@d_endhent@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2347,		T_INV,0,ALN64I"@@d_tcsetpgrp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2348,		T_INV,0,ALN64I"@@d_gethname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2352,		T_INV,0,ALN64I"@@d_vendorbin@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2792,		T_INV,0,ALN64I"@@shmattype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2359,		T_INV,0,ALN64I"@@d_msgget@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2802,		T_INV,0,ALN64I"@@baserev@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2366,			T_INV,0,ALN64I"@@_exe@@"},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2817,		T_INV,0,ALN64I"@@alignbytes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2368,		T_INV,0,ALN64I"@@ccstdflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2369,		T_INV,0,ALN64I"@@d_pwcomment@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2370,		T_INV,0,ALN64I"@@baserev@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2377,		T_INV,0,ALN64I"@@sPRIx64@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2826,	T_INV,0,ALN64I"@@d_getprotobyname_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2386,		T_INV,0,ALN64I"@@d_fchmod@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2831,		T_INV,0,ALN64I"@@d_copysignl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2387,		T_INV,0,ALN64I"@@sitebinexp@@"},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2841,		T_INV,0,ALN64I"@@d_tcgetpgrp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2389,		T_INV,0,ALN64I"@@d_dir_dd_fd@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2391,		T_INV,0,ALN64I"@@vendorlib@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2392,		T_INV,0,ALN64I"@@privlib@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2394,		T_INV,0,ALN64I"@@d_pwgecos@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2395,		T_INV,0,ALN64I"@@usethreads@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2844,		T_INV,0,ALN64I"@@d_expm1@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2848,		T_INV,0,ALN64I"@@d_socklen_t@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2864,		T_INV,0,ALN64I"@@d_setreuid@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2870,	T_INV,0,ALN64I"@@git_remote_branch@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2886,		T_INV,0,ALN64I"@@d_fsetpos@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2889,	T_INV,0,ALN64I"@@d_sin6_scope_id@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2901,		T_INV,0,ALN64I"@@orderlib@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2398,			T_INV,0,ALN64I"@@byacc@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2909,		T_INV,0,ALN64I"@@d_sigaction@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2406,	T_INV,0,ALN64I"@@perl_static_inline@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2412,		T_INV,0,ALN64I"@@i_gdbmndbm@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2914,		T_INV,0,ALN64I"@@d_getpbynumber@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2417,		T_INV,0,ALN64I"@@d_getpgid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2916,		T_INV,0,ALN64I"@@myarchname@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2424,			T_INV,0,ALN64I"@@u8size@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2425,			T_INV,0,ALN64I"@@extras@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2920,	T_INV,0,ALN64I"@@setlocale_r_proto@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2429,			T_INV,0,ALN64I"@@dlext@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2922,		T_INV,0,ALN64I"@@installbin@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2430,		T_INV,0,ALN64I"@@sGMTIME_max@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2927,		T_INV,0,ALN64I"@@i_vfork@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2433,	T_INV,0,ALN64I"@@installsiteman3dir@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2928,		T_INV,0,ALN64I"@@d_vfork@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2434,		T_INV,0,ALN64I"@@d_PRIx64@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2943,		T_INV,0,ALN64I"@@i_sysdir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2437,		T_INV,0,ALN64I"@@cppstdin@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2958,		T_INV,0,ALN64I"@@d_shmget@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2438,	T_INV,0,ALN64I"@@installsiteman1dir@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2960,		T_INV,0,ALN64I"@@git_describe@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2439,		T_INV,0,ALN64I"@@d_vendorscript@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2961,		T_INV,0,ALN64I"@@d_pwclass@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2963,		T_INV,0,ALN64I"@@d_vsnprintf@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2440,		T_INV,0,ALN64I"@@d_malloc_size@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2967,		T_INV,0,ALN64I"@@d_snprintf@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2968,		T_INV,0,ALN64I"@@i_varargs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2974,		T_INV,0,ALN64I"@@i_sysparam@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2444,			T_INV,0,ALN64I"@@bash@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2977,		T_INV,0,ALN64I"@@d_wctomb@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2447,		T_INV,0,ALN64I"@@d_dosuid@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2982,	T_INV,0,ALN64I"@@d_sprintf_returns_strlen@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2452,		T_INV,0,ALN64I"@@d_syscall@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2453,		T_INV,0,ALN64I"@@d_stdstdio@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2466,		T_INV,0,ALN64I"@@d_sitearch@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2985,		T_INV,0,ALN64I"@@d_nearbyint@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2469,		T_INV,0,ALN64I"@@eunicefix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2475,	T_INV,0,ALN64I"@@d_old_pthread_create_joinable@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2476,		T_INV,0,ALN64I"@@i_sysstatfs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2483,	T_INV,0,ALN64I"@@ttyname_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2484,			T_INV,0,ALN64I"@@uniq@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2486,		T_INV,0,ALN64I"@@intsize@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2488,		T_INV,0,ALN64I"@@locincpth@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2494,		T_INV,0,ALN64I"@@vaproto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2495,		T_INV,0,ALN64I"@@d_dbl_dig@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2499,		T_INV,0,ALN64I"@@cppflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2507,		T_INV,0,ALN64I"@@d_fpclassify@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2515,			T_INV,0,ALN64I"@@i_fenv@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2516,		T_INV,0,ALN64I"@@i16size@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2518,		T_INV,0,ALN64I"@@i64size@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2523,			T_INV,0,ALN64I"@@d_quad@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2533,		T_INV,0,ALN64I"@@d_setlocale_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2536,		T_INV,0,ALN64I"@@d_portable@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2541,		T_INV,0,ALN64I"@@d_wctomb@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2545,		T_INV,0,ALN64I"@@i32size@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2556,			T_INV,0,ALN64I"@@chgrp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2557,		T_INV,0,ALN64I"@@cccdlflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2558,		T_INV,0,ALN64I"@@stdio_filbuf@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2559,		T_INV,0,ALN64I"@@d_setresuid@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2560,		T_INV,0,ALN64I"@@d_nl_langinfo@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2567,		T_INV,0,ALN64I"@@d_re_comp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2570,		T_INV,0,ALN64I"@@sLOCALTIME_max@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2572,			T_INV,0,ALN64I"@@expr@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2579,		T_INV,0,ALN64I"@@d_getnameinfo@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2583,		T_INV,0,ALN64I"@@full_csh@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2589,		T_INV,0,ALN64I"@@lddlflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2594,			T_INV,0,ALN64I"@@d_exp2@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2600,		T_INV,0,ALN64I"@@d_localtime64@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2603,			T_INV,0,ALN64I"@@mailx@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2610,		T_INV,0,ALN64I"@@selectminbits@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2613,	T_INV,0,ALN64I"@@netdb_host_type@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2618,		T_INV,0,ALN64I"@@gidtype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2620,	T_INV,0,ALN64I"@@d_getnetbyname_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2627,		T_INV,0,ALN64I"@@d_fs_data_s@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2633,		T_INV,0,ALN64I"@@castflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2638,	T_INV,0,ALN64I"@@netdb_name_type@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2641,		T_INV,0,ALN64I"@@cppminus@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2653,		T_INV,0,ALN64I"@@d_setpwent@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2656,		T_INV,0,ALN64I"@@d_endpwent@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2661,		T_INV,0,ALN64I"@@d_mbstowcs@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2663,			T_INV,0,ALN64I"@@libpth@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2670,		T_INV,0,ALN64I"@@d_fpos64_t@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2678,		T_INV,0,ALN64I"@@i_inttypes@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2679,			T_INV,0,ALN64I"@@madlyh@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2681,		T_INV,0,ALN64I"@@i_vfork@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2682,		T_INV,0,ALN64I"@@d_vfork@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2687,		T_INV,0,ALN64I"@@d_statfs_s@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2688,		T_INV,0,ALN64I"@@d_fsetpos@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2690,		T_INV,0,ALN64I"@@ptrsize@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2691,	T_INV,0,ALN64I"@@setprotoent_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2694,	T_INV,0,ALN64I"@@endprotoent_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2698,		T_INV,0,ALN64I"@@d_pwclass@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2700,		T_INV,0,ALN64I"@@targetenv@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2730,		T_INV,0,ALN64I"@@groupcat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2731,		T_INV,0,ALN64I"@@scriptdirexp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2732,		T_INV,0,ALN64I"@@nvmantbits@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2733,		T_INV,0,ALN64I"@@i_arpainet@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2737,		T_INV,0,ALN64I"@@signal_t@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2741,		T_INV,0,ALN64I"@@d_volatile@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2744,		T_INV,0,ALN64I"@@d_expm1@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2751,		T_INV,0,ALN64I"@@sig_name_init@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2759,			T_INV,0,ALN64I"@@cf_by@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2760,		T_INV,0,ALN64I"@@d_newlocale@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2766,		T_INV,0,ALN64I"@@ccsymbols@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2767,		T_INV,0,ALN64I"@@d_closedir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2773,		T_INV,0,ALN64I"@@d_semctl_semun@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2778,		T_INV,0,ALN64I"@@d_syscallproto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2994,		T_INV,0,ALN64I"@@targetarch@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2787,	T_INV,0,ALN64I"@@d_semctl_semid_ds@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2793,		T_INV,0,ALN64I"@@i_sgtty@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2794,	T_INV,0,ALN64I"@@d_siginfo_si_band@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2996,		T_INV,0,ALN64I"@@fflushNULL@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2796,		T_INV,0,ALN64I"@@ccdlflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2797,		T_INV,0,ALN64I"@@d_vsnprintf@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2798,		T_INV,0,ALN64I"@@myhostname@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2800,	T_INV,0,ALN64I"@@sethostent_r_proto@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2999,		T_INV,0,ALN64I"@@d_socket@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3000,			T_INV,0,ALN64I"@@d_fork@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3016,			T_INV,0,ALN64I"@@uvsize@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2803,	T_INV,0,ALN64I"@@endhostent_r_proto@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3018,		T_INV,0,ALN64I"@@d_volatile@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3020,		T_INV,0,ALN64I"@@d_oldpthreads@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3030,		T_INV,0,ALN64I"@@doop_cflags@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3031,			T_INV,0,ALN64I"@@flex@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3032,		T_INV,0,ALN64I"@@gccversion@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3039,	T_INV,0,ALN64I"@@getprotobyname_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3040,		T_INV,0,ALN64I"@@d_newlocale@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2805,		T_INV,0,ALN64I"@@d_asctime_r@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3049,		T_INV,0,ALN64I"@@d_getppid@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2814,		T_INV,0,ALN64I"@@d_asctime64@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3054,	T_INV,0,ALN64I"@@d_gethostprotos@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2819,		T_INV,0,ALN64I"@@d_seekdir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2820,		T_INV,0,ALN64I"@@d_ttyname_r@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3059,	T_INV,0,ALN64I"@@getnetent_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3060,		T_INV,0,ALN64I"@@selectminbits@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3063,		T_INV,0,ALN64I"@@d_phostname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3067,		T_INV,0,ALN64I"@@man3ext@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3070,		T_INV,0,ALN64I"@@myhostname@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3073,	T_INV,0,ALN64I"@@d_setprotoent_r@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3076,	T_INV,0,ALN64I"@@d_endprotoent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3080,	T_INV,0,ALN64I"@@d_stdio_cnt_lval@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3082,		T_INV,0,ALN64I"@@d_getpagsz@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3085,			T_INV,0,ALN64I"@@prefix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3090,	T_INV,0,ALN64I"@@longdblmantbits@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3092,		T_INV,0,ALN64I"@@d_getgrnam_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3099,		T_INV,0,ALN64I"@@d_mbstowcs@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3101,		T_INV,0,ALN64I"@@man1ext@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3105,	T_INV,0,ALN64I"@@netdb_host_type@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3106,		T_INV,0,ALN64I"@@targetmkdir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3113,		T_INV,0,ALN64I"@@d_pwcomment@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3120,		T_INV,0,ALN64I"@@i_rpcsvcdbm@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3124,	T_INV,0,ALN64I"@@installvendorscript@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3125,		T_INV,0,ALN64I"@@d_msgrcv@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3128,	T_INV,0,ALN64I"@@netdb_name_type@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3129,		T_INV,0,ALN64I"@@d_unsetenv@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3130,		T_INV,0,ALN64I"@@installsitelib@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2825,		T_INV,0,ALN64I"@@cf_email@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3138,	T_INV,0,ALN64I"@@sethostent_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3141,	T_INV,0,ALN64I"@@endhostent_r_proto@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3142,		T_INV,0,ALN64I"@@usedevel@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3146,		T_INV,0,ALN64I"@@d_pwgecos@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3150,		T_INV,0,ALN64I"@@d_setpwent_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3151,		T_INV,0,ALN64I"@@d_getnbyaddr@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2833,		T_INV,0,ALN64I"@@d_gmtime_r@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3153,		T_INV,0,ALN64I"@@d_endpwent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3162,		T_INV,0,ALN64I"@@need_va_copy@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3163,		T_INV,0,ALN64I"@@d_hypot@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3171,		T_INV,0,ALN64I"@@i_values@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3174,		T_INV,0,ALN64I"@@git_commit_id@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3175,		T_INV,0,ALN64I"@@targetport@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3176,		T_INV,0,ALN64I"@@d_gethent@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3179,		T_INV,0,ALN64I"@@usemallocwrap@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3183,		T_INV,0,ALN64I"@@d_vendorlib@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3186,	T_INV,0,ALN64I"@@setservent_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3189,	T_INV,0,ALN64I"@@endservent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3199,		T_INV,0,ALN64I"@@phostname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3208,			T_INV,0,ALN64I"@@d_fmax@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3214,		T_INV,0,ALN64I"@@usemymalloc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3219,		T_INV,0,ALN64I"@@installhtmldir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3220,		T_INV,0,ALN64I"@@vendorhtml3dir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3222,		T_INV,0,ALN64I"@@ieeefp_h@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3223,		T_INV,0,ALN64I"@@d_vprintf@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3224,		T_INV,0,ALN64I"@@random_r_proto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3226,		T_INV,0,ALN64I"@@loclibpth@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3231,		T_INV,0,ALN64I"@@d_fegetround@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3234,		T_INV,0,ALN64I"@@d_voidtty@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3237,		T_INV,0,ALN64I"@@d_getcwd@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3241,		T_INV,0,ALN64I"@@d_sockatmark@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3243,	T_INV,0,ALN64I"@@d_c99_variadic_macros@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3247,		T_INV,0,ALN64I"@@d_log1p@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3250,	T_INV,0,ALN64I"@@installvendorman3dir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3252,		T_INV,0,ALN64I"@@installstyle@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3254,		T_INV,0,ALN64I"@@vendorhtml1dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3255,		T_INV,0,ALN64I"@@d_strxfrm@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3257,			T_INV,0,ALN64I"@@nvtype@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3259,			T_INV,0,ALN64I"@@ivtype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3263,		T_INV,0,ALN64I"@@d_setregid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3264,			T_INV,0,ALN64I"@@binexp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3270,	T_INV,0,ALN64I"@@git_commit_id_title@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3271,			T_INV,0,ALN64I"@@gmake@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3274,		T_INV,0,ALN64I"@@d_regcomp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3283,		T_INV,0,ALN64I"@@defvoidused@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3284,	T_INV,0,ALN64I"@@installvendorman1dir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3285,		T_INV,0,ALN64I"@@issymlink@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3290,		T_INV,0,ALN64I"@@d_symlink@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3294,	T_INV,0,ALN64I"@@d_static_inline@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3303,	T_INV,0,ALN64I"@@db_version_minor@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3306,		T_INV,0,ALN64I"@@d_sockaddr_in6@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3307,		T_INV,0,ALN64I"@@nveformat@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3310,		T_INV,0,ALN64I"@@api_subversion@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3312,		T_INV,0,ALN64I"@@ivdformat@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3314,	T_INV,0,ALN64I"@@d_malloc_good_size@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3321,		T_INV,0,ALN64I"@@d_lockf@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3323,		T_INV,0,ALN64I"@@cppccsymbols@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3326,	T_INV,0,ALN64I"@@d_pthread_yield@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3330,		T_INV,0,ALN64I"@@tmpnam_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3333,		T_INV,0,ALN64I"@@d_setvbuf@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3338,		T_INV,0,ALN64I"@@d_fpgetround@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3343,		T_INV,0,ALN64I"@@xlibpth@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3348,		T_INV,0,ALN64I"@@d_localtime_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3376,	T_INV,0,ALN64I"@@d_localtime_r_needs_tzset@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3378,		T_INV,0,ALN64I"@@d_ptrdiff_t@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3382,		T_INV,0,ALN64I"@@yaccflags@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3383,		T_INV,0,ALN64I"@@d_grpasswd@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3385,		T_INV,0,ALN64I"@@subversion@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3391,		T_INV,0,ALN64I"@@d_memmove@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3406,		T_INV,0,ALN64I"@@timetype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3416,		T_INV,0,ALN64I"@@d_recvmsg@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3418,	T_INV,0,ALN64I"@@d_getnetbyaddr_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3440,		T_INV,0,ALN64I"@@shrpenv@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3442,		T_INV,0,ALN64I"@@madlyobj@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3444,		T_INV,0,ALN64I"@@targetenv@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3447,		T_INV,0,ALN64I"@@i_varhdr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3455,		T_INV,0,ALN64I"@@d_union_semun@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3459,		T_INV,0,ALN64I"@@d_sigprocmask@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3466,		T_INV,0,ALN64I"@@i_shadow@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3468,		T_INV,0,ALN64I"@@installprivlib@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3469,		T_INV,0,ALN64I"@@privlibexp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3470,		T_INV,0,ALN64I"@@html3dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3475,	T_INV,0,ALN64I"@@getprotoent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3483,		T_INV,0,ALN64I"@@d_getespwnam@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3488,		T_INV,0,ALN64I"@@d_xenix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3496,	T_INV,0,ALN64I"@@getnetbyaddr_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3499,		T_INV,0,ALN64I"@@lseektype@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3501,	T_INV,0,ALN64I"@@installsitearch@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3504,		T_INV,0,ALN64I"@@html1dir@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3507,	T_INV,0,ALN64I"@@ccflags_nolargefiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3513,	T_INV,0,ALN64I"@@getgrent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3519,			T_INV,0,ALN64I"@@chown@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3523,			T_INV,0,ALN64I"@@ksh@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3526,	T_INV,0,ALN64I"@@d_statfs_f_flags@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3529,		T_INV,0,ALN64I"@@sig_count@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3537,		T_INV,0,ALN64I"@@d_pwage@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3541,		T_INV,0,ALN64I"@@d_getpwent@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3544,	T_INV,0,ALN64I"@@d_shmatprototype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3549,		T_INV,0,ALN64I"@@uselongdouble@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3550,	T_INV,0,ALN64I"@@netdb_hlen_type@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3551,		T_INV,0,ALN64I"@@i_sysuio@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3555,		T_INV,0,ALN64I"@@d_setpgrp@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3558,	T_INV,0,ALN64I"@@getspnam_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3573,	T_INV,0,ALN64I"@@ldflags_nolargefiles@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3575,		T_INV,0,ALN64I"@@mydomain@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3582,		T_INV,0,ALN64I"@@d_mbtowc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3588,		T_INV,0,ALN64I"@@d_getprpwnam@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3590,		T_INV,0,ALN64I"@@randseedtype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3591,	T_INV,0,ALN64I"@@installprefixexp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3598,		T_INV,0,ALN64I"@@d_msghdr_s@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3604,		T_INV,0,ALN64I"@@modetype@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3606,		T_INV,0,ALN64I"@@d_voidsig@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3607,		T_INV,0,ALN64I"@@extern_C@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3624,		T_INV,0,ALN64I"@@d_memcpy@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3635,	T_INV,0,ALN64I"@@usesitecustomize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3640,	T_INV,0,ALN64I"@@longdblnanbytes@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3648,		T_INV,0,ALN64I"@@libswanted@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3649,	T_INV,0,ALN64I"@@longdblinfbytes@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3650,		T_INV,0,ALN64I"@@d_strctcpy@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3661,		T_INV,0,ALN64I"@@lib_ext@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3663,	T_INV,0,ALN64I"@@d_sockatmarkproto@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3665,		T_INV,0,ALN64I"@@d_gettimeod@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3678,		T_INV,0,ALN64I"@@mallocobj@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3679,		T_INV,0,ALN64I"@@config_args@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3680,		T_INV,0,ALN64I"@@libsfound@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3681,		T_INV,0,ALN64I"@@d_getlogin@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3682,			T_INV,0,ALN64I"@@uvtype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3683,		T_INV,0,ALN64I"@@d_setpgrp2@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3685,		T_INV,0,ALN64I"@@config_argc@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3686,		T_INV,0,ALN64I"@@config_arg8@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3689,		T_INV,0,ALN64I"@@config_arg3@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3690,		T_INV,0,ALN64I"@@config_arg6@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3691,		T_INV,0,ALN64I"@@cpp_stuff@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3692,		T_INV,0,ALN64I"@@config_arg39@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3693,		T_INV,0,ALN64I"@@d_setlinebuf@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3697,		T_INV,0,ALN64I"@@config_arg4@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3698,		T_INV,0,ALN64I"@@config_arg35@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3699,		T_INV,0,ALN64I"@@config_arg38@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3700,		T_INV,0,ALN64I"@@selecttype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3701,		T_INV,0,ALN64I"@@config_arg30@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3702,		T_INV,0,ALN64I"@@config_arg33@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3704,		T_INV,0,ALN64I"@@spackage@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3705,		T_INV,0,ALN64I"@@config_arg0@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3706,		T_INV,0,ALN64I"@@config_arg37@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3708,		T_INV,0,ALN64I"@@clocktype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3709,		T_INV,0,ALN64I"@@config_arg31@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3711,		T_INV,0,ALN64I"@@d_fgetpos@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3712,		T_INV,0,ALN64I"@@config_arg9@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3713,		T_INV,0,ALN64I"@@d_getsbyname@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3714,		T_INV,0,ALN64I"@@d_getnbyname@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3715,		T_INV,0,ALN64I"@@i_systime@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3716,		T_INV,0,ALN64I"@@config_arg5@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3717,		T_INV,0,ALN64I"@@i_systimes@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3719,		T_INV,0,ALN64I"@@sizetype@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3722,		T_INV,0,ALN64I"@@git_branch@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3723,		T_INV,0,ALN64I"@@config_arg1@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3724,		T_INV,0,ALN64I"@@config_arg36@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3726,		T_INV,0,ALN64I"@@config_arg19@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3728,		T_INV,0,ALN64I"@@config_arg32@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3729,		T_INV,0,ALN64I"@@d_chown@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3730,		T_INV,0,ALN64I"@@i_sysutsname@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3732,		T_INV,0,ALN64I"@@config_arg15@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3733,		T_INV,0,ALN64I"@@config_arg18@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3735,		T_INV,0,ALN64I"@@config_arg10@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3736,		T_INV,0,ALN64I"@@config_arg13@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3737,		T_INV,0,ALN64I"@@config_arg7@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3740,		T_INV,0,ALN64I"@@config_arg17@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3743,		T_INV,0,ALN64I"@@config_arg11@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3747,		T_INV,0,ALN64I"@@d_socks5_init@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3748,		T_INV,0,ALN64I"@@mmaptype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3749,		T_INV,0,ALN64I"@@config_arg34@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3757,	T_INV,0,ALN64I"@@installvendorbin@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3758,		T_INV,0,ALN64I"@@config_arg16@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3759,		T_INV,0,ALN64I"@@d_fchdir@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3762,		T_INV,0,ALN64I"@@config_arg12@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3765,	T_INV,0,ALN64I"@@d_getservprotos@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3773,		T_INV,0,ALN64I"@@st_ino_size@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3776,		T_INV,0,ALN64I"@@freetype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3777,		T_INV,0,ALN64I"@@package@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3783,		T_INV,0,ALN64I"@@config_arg14@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3785,		T_INV,0,ALN64I"@@lkflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3797,		T_INV,0,ALN64I"@@i_langinfo@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3798,		T_INV,0,ALN64I"@@o_nonblock@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3805,		T_INV,0,ALN64I"@@config_arg2@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3806,		T_INV,0,ALN64I"@@d_safemcpy@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3808,		T_INV,0,ALN64I"@@config_arg29@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3811,		T_INV,0,ALN64I"@@d_safebcpy@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3814,		T_INV,0,ALN64I"@@config_arg25@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3815,		T_INV,0,ALN64I"@@config_arg28@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3817,		T_INV,0,ALN64I"@@config_arg20@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3818,		T_INV,0,ALN64I"@@config_arg23@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3819,		T_INV,0,ALN64I"@@nvGUformat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3820,		T_INV,0,ALN64I"@@nvEUformat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3821,		T_INV,0,ALN64I"@@d_getpbyname@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3822,		T_INV,0,ALN64I"@@config_arg27@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3824,		T_INV,0,ALN64I"@@nvFUformat@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3825,		T_INV,0,ALN64I"@@config_arg21@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3830,	T_INV,0,ALN64I"@@installvendorlib@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3840,		T_INV,0,ALN64I"@@config_arg26@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3844,		T_INV,0,ALN64I"@@config_arg22@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3865,		T_INV,0,ALN64I"@@config_arg24@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3879,		T_INV,0,ALN64I"@@nvfformat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3886,		T_INV,0,ALN64I"@@cryptlib@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3890,		T_INV,0,ALN64I"@@d_sethostent_r@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3893,		T_INV,0,ALN64I"@@d_endhostent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3898,	T_INV,0,ALN64I"@@d_getprotoent_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3900,	T_INV,0,ALN64I"@@perl_patchlevel@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3906,		T_INV,0,ALN64I"@@regexec_cflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3916,		T_INV,0,ALN64I"@@d_getspnam@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3921,		T_INV,0,ALN64I"@@db_prefixtype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3925,		T_INV,0,ALN64I"@@hostgenerate@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3929,		T_INV,0,ALN64I"@@d_fstatvfs@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3930,		T_INV,0,ALN64I"@@uvoformat@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3932,	T_INV,0,ALN64I"@@git_commit_date@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3937,		T_INV,0,ALN64I"@@d_gnulibc@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3939,	T_INV,0,ALN64I"@@setpwent_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3942,	T_INV,0,ALN64I"@@endpwent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3948,		T_INV,0,ALN64I"@@d_sigsetjmp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3963,	T_INV,0,ALN64I"@@gethostent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3973,		T_INV,0,ALN64I"@@use64bitall@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3975,		T_INV,0,ALN64I"@@d_getpwent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3981,		T_INV,0,ALN64I"@@i_sysvfs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3986,	T_INV,0,ALN64I"@@d_getprotobynumber_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4001,		T_INV,0,ALN64I"@@d_lchown@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4009,		T_INV,0,ALN64I"@@i_gdbm_ndbm@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4011,	T_INV,0,ALN64I"@@getservent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4022,		T_INV,0,ALN64I"@@gmtime_r_proto@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4025,	T_INV,0,ALN64I"@@d_printf_format_null@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4029,		T_INV,0,ALN64I"@@usemorebits@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4031,		T_INV,0,ALN64I"@@d_mkfifo@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4034,	T_INV,0,ALN64I"@@d_fcntl_can_lock@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4036,		T_INV,0,ALN64I"@@fflushall@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4042,		T_INV,0,ALN64I"@@versiononly@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4059,	T_INV,0,ALN64I"@@getnetbyname_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4063,	T_INV,0,ALN64I"@@libs_nolargefiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4068,		T_INV,0,ALN64I"@@fpostype@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4071,		T_INV,0,ALN64I"@@st_ino_sign@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4076,		T_INV,0,ALN64I"@@direntrytype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4083,		T_INV,0,ALN64I"@@procselfexe@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4090,		T_INV,0,ALN64I"@@i_xlocale@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4114,		T_INV,0,ALN64I"@@uselargefiles@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4115,		T_INV,0,ALN64I"@@d_getlogin_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4127,		T_INV,0,ALN64I"@@d_waitpid@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4128,	T_INV,0,ALN64I"@@d_pthread_attr_setscope@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4131,		T_INV,0,ALN64I"@@nvgformat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4148,		T_INV,0,ALN64I"@@i_sysfile@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4157,		T_INV,0,ALN64I"@@uvuformat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4186,		T_INV,0,ALN64I"@@d_nextafter@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4187,		T_INV,0,ALN64I"@@canned_gperf@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4195,		T_INV,0,ALN64I"@@uquadtype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4209,		T_INV,0,ALN64I"@@malloctype@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4210,			T_INV,0,ALN64I"@@awk@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4212,	T_INV,0,ALN64I"@@localtime_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2835,		T_INV,0,ALN64I"@@doublemantbits@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4230,		T_INV,0,ALN64I"@@api_version@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4233,		T_INV,0,ALN64I"@@d_backtrace@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4244,		T_INV,0,ALN64I"@@uvXUformat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4274,		T_INV,0,ALN64I"@@longlongsize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4285,		T_INV,0,ALN64I"@@i_syswait@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4288,	T_INV,0,ALN64I"@@getgrnam_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4296,		T_INV,0,ALN64I"@@d_bsdsetpgrp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4306,		T_INV,0,ALN64I"@@ccversion@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2853,		T_INV,0,ALN64I"@@d_pwage@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4312,	T_INV,0,ALN64I"@@db_version_patch@@"},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2859,		T_INV,0,ALN64I"@@useithreads@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4314,		T_INV,0,ALN64I"@@dynamic_ext@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2860,		T_INV,0,ALN64I"@@d_copysign@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4340,		T_INV,0,ALN64I"@@sharpbang@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2861,		T_INV,0,ALN64I"@@shrpenv@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4345,		T_INV,0,ALN64I"@@i_quadmath@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2866,			T_INV,0,ALN64I"@@chown@@"},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4346,	T_INV,0,ALN64I"@@installsitescript@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2868,			T_INV,0,ALN64I"@@d_link@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4350,		T_INV,0,ALN64I"@@d_getspnam_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4351,	T_INV,0,ALN64I"@@d_builtin_choose_expr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4360,	T_INV,0,ALN64I"@@installvendorarch@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4368,	T_INV,0,ALN64I"@@sitehtml3direxp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4380,		T_INV,0,ALN64I"@@d_getpgrp@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4383,	T_INV,0,ALN64I"@@gethostbyname_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2869,		T_INV,0,ALN64I"@@op_cflags@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4388,		T_INV,0,ALN64I"@@vendorarch@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4389,		T_INV,0,ALN64I"@@vendorscript@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4408,	T_INV,0,ALN64I"@@d_siginfo_si_value@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4410,		T_INV,0,ALN64I"@@vendorarchexp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4411,	T_INV,0,ALN64I"@@d_vms_case_sensitive_symbols@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4431,	T_INV,0,ALN64I"@@getservbyname_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4446,		T_INV,0,ALN64I"@@longdblsize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4451,		T_INV,0,ALN64I"@@sitearchexp@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4452,		T_INV,0,ALN64I"@@api_revision@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4471,		T_INV,0,ALN64I"@@shortsize@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4472,		T_INV,0,ALN64I"@@d_gethbyaddr@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4476,	T_INV,0,ALN64I"@@sitehtml1direxp@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4478,		T_INV,0,ALN64I"@@make_set_make@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4489,		T_INV,0,ALN64I"@@usecbacktrace@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4500,		T_INV,0,ALN64I"@@d_fchown@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4508,		T_INV,0,ALN64I"@@d_getpgrp2@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4509,		T_INV,0,ALN64I"@@voidflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4533,		T_INV,0,ALN64I"@@ctime_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4543,		T_INV,0,ALN64I"@@archobjs@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4545,		T_INV,0,ALN64I"@@ccwarnflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4556,	T_INV,0,ALN64I"@@libdb_needs_pthread@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4560,		T_INV,0,ALN64I"@@ldlibpthname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4565,		T_INV,0,ALN64I"@@malloc_cflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4579,		T_INV,0,ALN64I"@@d_remquo@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4598,	T_INV,0,ALN64I"@@d_perl_otherlibdirs@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4601,		T_INV,0,ALN64I"@@d_setservent_r@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4604,		T_INV,0,ALN64I"@@d_endservent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4613,	T_INV,0,ALN64I"@@d_gethostbyaddr_r@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4615,		T_INV,0,ALN64I"@@extensions@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4616,	T_INV,0,ALN64I"@@installvendorhtml3dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4634,		T_INV,0,ALN64I"@@d_pwpasswd@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4635,		T_INV,0,ALN64I"@@d_ldexpl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4643,		T_INV,0,ALN64I"@@d_writev@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4650,	T_INV,0,ALN64I"@@installvendorhtml1dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4674,	T_INV,0,ALN64I"@@installsitehtml3dir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4691,		T_INV,0,ALN64I"@@perl_revision@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4703,		T_INV,0,ALN64I"@@d_attribut@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4707,		T_INV,0,ALN64I"@@d_madvise@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4708,	T_INV,0,ALN64I"@@installsitehtml1dir@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4710,		T_INV,0,ALN64I"@@vendorlib_stem@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4715,		T_INV,0,ALN64I"@@d_gethostent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4749,	T_INV,0,ALN64I"@@usekernprocpathname@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4750,		T_INV,0,ALN64I"@@d_getpwnam_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4761,		T_INV,0,ALN64I"@@d_getgrgid_r@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4764,	T_INV,0,ALN64I"@@getpwent_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4782,		T_INV,0,ALN64I"@@shsharp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4786,	T_INV,0,ALN64I"@@installhtmlhelpdir@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4787,		T_INV,0,ALN64I"@@d_ldbl_dig@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2874,		T_INV,0,ALN64I"@@i_shadow@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4827,		T_INV,0,ALN64I"@@patchlevel@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4835,	T_INV,0,ALN64I"@@useversionedarchname@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4853,		T_INV,0,ALN64I"@@d_flexfnam@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2887,	T_INV,0,ALN64I"@@d_setprotoent_r@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4873,		T_INV,0,ALN64I"@@vendorbinexp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2889,	T_INV,0,ALN64I"@@d_c99_variadic_macros@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4879,	T_INV,0,ALN64I"@@inc_version_list@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2890,	T_INV,0,ALN64I"@@d_endprotoent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2897,		T_INV,0,ALN64I"@@d_sigaction@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4881,		T_INV,0,ALN64I"@@use64bitint@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2899,		T_INV,0,ALN64I"@@d_shmget@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2901,		T_INV,0,ALN64I"@@myarchname@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2902,	T_INV,0,ALN64I"@@d_getprotobyname_r@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4886,		T_INV,0,ALN64I"@@vendorlibexp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2907,		T_INV,0,ALN64I"@@uidsize@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4893,	T_INV,0,ALN64I"@@inc_version_list_init@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2914,		T_INV,0,ALN64I"@@i_varargs@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4909,	T_INV,0,ALN64I"@@d_gdbmndbm_h_uses_prototypes@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2915,		T_INV,0,ALN64I"@@d_setreuid@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4917,		T_INV,0,ALN64I"@@toke_cflags@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2918,		T_INV,0,ALN64I"@@d_getpbynumber@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4942,		T_INV,0,ALN64I"@@useposix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2919,		T_INV,0,ALN64I"@@d_copysignl@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4950,		T_INV,0,ALN64I"@@d_scm_rights@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4958,		T_INV,0,ALN64I"@@quadkind@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2922,		T_INV,0,ALN64I"@@installarchlib@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4996,	T_INV,0,ALN64I"@@ignore_versioned_solibs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2924,		T_INV,0,ALN64I"@@fflushNULL@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5017,		T_INV,0,ALN64I"@@d__fwalk@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5027,	T_INV,0,ALN64I"@@getservbyport_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2925,		T_INV,0,ALN64I"@@d_unsetenv@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5035,		T_INV,0,ALN64I"@@d_gethbyname@@"},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2933,		T_INV,0,ALN64I"@@u16size@@"},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5038,	T_INV,0,ALN64I"@@git_uncommitted_changes@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2935,		T_INV,0,ALN64I"@@u64size@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5090,		T_INV,0,ALN64I"@@sig_num_init@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2942,	T_INV,0,ALN64I"@@git_remote_branch@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2944,		T_INV,0,ALN64I"@@d_lgamma_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2945,			T_INV,0,ALN64I"@@flex@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2950,		T_INV,0,ALN64I"@@i_rpcsvcdbm@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2953,		T_INV,0,ALN64I"@@d_getnetent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2958,		T_INV,0,ALN64I"@@d_chown@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2962,		T_INV,0,ALN64I"@@u32size@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2964,		T_INV,0,ALN64I"@@d_mkdir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2965,			T_INV,0,ALN64I"@@gzip@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2966,		T_INV,0,ALN64I"@@d_mktime@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2970,	T_INV,0,ALN64I"@@setgrent_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2973,	T_INV,0,ALN64I"@@endgrent_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2977,			T_INV,0,ALN64I"@@make@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2980,			T_INV,0,ALN64I"@@mkdir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2987,		T_INV,0,ALN64I"@@ansi2knr@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5096,	T_INV,0,ALN64I"@@vendorman3direxp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2993,		T_INV,0,ALN64I"@@man3ext@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2996,		T_INV,0,ALN64I"@@usedevel@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str2998,		T_INV,0,ALN64I"@@man1ext@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3000,	T_INV,0,ALN64I"@@d_getservprotos@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3001,		T_INV,0,ALN64I"@@mips_type@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3003,		T_INV,0,ALN64I"@@d_msgrcv@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3012,	T_INV,0,ALN64I"@@installvendorman3dir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3013,		T_INV,0,ALN64I"@@d_oldpthreads@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3015,		T_INV,0,ALN64I"@@archlibexp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3017,	T_INV,0,ALN64I"@@installvendorman1dir@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3019,		T_INV,0,ALN64I"@@i_sysdir@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3020,	T_INV,0,ALN64I"@@d_sprintf_returns_strlen@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3023,		T_INV,0,ALN64I"@@libswanted@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3024,		T_INV,0,ALN64I"@@i_values@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3026,		T_INV,0,ALN64I"@@d_mktime64@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3028,		T_INV,0,ALN64I"@@i_socks@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3031,		T_INV,0,ALN64I"@@i_stdlib@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3034,		T_INV,0,ALN64I"@@charbits@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3036,		T_INV,0,ALN64I"@@sockethdr@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3039,		T_INV,0,ALN64I"@@defvoidused@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3044,		T_INV,0,ALN64I"@@prototype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3046,		T_INV,0,ALN64I"@@static_ext@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3047,	T_INV,0,ALN64I"@@getservent_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3048,			T_INV,0,ALN64I"@@Locker@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3050,		T_INV,0,ALN64I"@@targetport@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3059,		T_INV,0,ALN64I"@@vendorhtml3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3064,		T_INV,0,ALN64I"@@vendorhtml1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3072,	T_INV,0,ALN64I"@@getnetent_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3073,		T_INV,0,ALN64I"@@d_log1p@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3074,			T_INV,0,ALN64I"@@d_fmax@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3076,	T_INV,0,ALN64I"@@getprotobyname_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3077,		T_INV,0,ALN64I"@@nveformat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3078,		T_INV,0,ALN64I"@@d_setpwent_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3081,		T_INV,0,ALN64I"@@d_endpwent_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3082,		T_INV,0,ALN64I"@@ivdformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3093,		T_INV,0,ALN64I"@@d_snprintf@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3097,		T_INV,0,ALN64I"@@d_getppid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3103,			T_INV,0,ALN64I"@@prefix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3107,	T_INV,0,ALN64I"@@netdb_hlen_type@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3110,		T_INV,0,ALN64I"@@d_readlink@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3115,		T_INV,0,ALN64I"@@libspath@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5103,	T_INV,0,ALN64I"@@gethostbyaddr_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3122,		T_INV,0,ALN64I"@@installhtmldir@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3125,		T_INV,0,ALN64I"@@d_vprintf@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3129,		T_INV,0,ALN64I"@@d_union_semun@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3134,		T_INV,0,ALN64I"@@d_hypot@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3141,		T_INV,0,ALN64I"@@d_setservent_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3144,		T_INV,0,ALN64I"@@d_endservent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3148,		T_INV,0,ALN64I"@@d_memmove@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3149,	T_INV,0,ALN64I"@@installvendorscript@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3160,		T_INV,0,ALN64I"@@orderlib@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3161,	T_INV,0,ALN64I"@@d_gethostprotos@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3162,			T_INV,0,ALN64I"@@pmake@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3170,		T_INV,0,ALN64I"@@installstyle@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3175,		T_INV,0,ALN64I"@@d_gethent@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3179,		T_INV,0,ALN64I"@@d_tcgetpgrp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3181,	T_INV,0,ALN64I"@@setlocale_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3190,	T_INV,0,ALN64I"@@ldflags_nolargefiles@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3191,		T_INV,0,ALN64I"@@d_nearbyint@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3201,		T_INV,0,ALN64I"@@d_bzero@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3204,		T_INV,0,ALN64I"@@git_commit_id@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3210,		T_INV,0,ALN64I"@@installbin@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3228,			T_INV,0,ALN64I"@@nvtype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3230,			T_INV,0,ALN64I"@@ivtype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3252,		T_INV,0,ALN64I"@@usemymalloc@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3254,		T_INV,0,ALN64I"@@issymlink@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3256,		T_INV,0,ALN64I"@@d_symlink@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3263,		T_INV,0,ALN64I"@@d_strxfrm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3267,		T_INV,0,ALN64I"@@doop_cflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3268,		T_INV,0,ALN64I"@@d_fegetround@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3270,		T_INV,0,ALN64I"@@d_phostname@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3271,		T_INV,0,ALN64I"@@d_socklen_t@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3280,	T_INV,0,ALN64I"@@git_commit_id_title@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3281,		T_INV,0,ALN64I"@@timetype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3287,		T_INV,0,ALN64I"@@d_sigprocmask@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3300,		T_INV,0,ALN64I"@@d_getgrnam_r@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3302,		T_INV,0,ALN64I"@@d_sethostent_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3303,		T_INV,0,ALN64I"@@installsitelib@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3305,		T_INV,0,ALN64I"@@d_endhostent_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3308,		T_INV,0,ALN64I"@@gccversion@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3314,		T_INV,0,ALN64I"@@socketlib@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3319,		T_INV,0,ALN64I"@@gidsize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3327,		T_INV,0,ALN64I"@@d_setregid@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3328,		T_INV,0,ALN64I"@@need_va_copy@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3330,	T_INV,0,ALN64I"@@d_stdio_cnt_lval@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5119,	T_INV,0,ALN64I"@@db_version_major@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3346,	T_INV,0,ALN64I"@@d_pthread_yield@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3347,		T_INV,0,ALN64I"@@targetarch@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5121,		T_INV,0,ALN64I"@@d_bsdgetpgrp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3349,		T_INV,0,ALN64I"@@d_getcwd@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5130,	T_INV,0,ALN64I"@@vendorman1direxp@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5133,		T_INV,0,ALN64I"@@dtraceobject@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3362,		T_INV,0,ALN64I"@@d_tmpnam_r@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5135,		T_INV,0,ALN64I"@@firstmakefile@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3364,		T_INV,0,ALN64I"@@modetype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3366,		T_INV,0,ALN64I"@@phostname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3377,	T_INV,0,ALN64I"@@longdblmantbits@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3378,		T_INV,0,ALN64I"@@api_subversion@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3379,		T_INV,0,ALN64I"@@d_waitpid@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3385,		T_INV,0,ALN64I"@@d_setvbuf@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5143,		T_INV,0,ALN64I"@@d_frexpl@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3393,		T_INV,0,ALN64I"@@d_bcopy@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5144,		T_INV,0,ALN64I"@@perl_version@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3397,	T_INV,0,ALN64I"@@ccflags_nolargefiles@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3398,		T_INV,0,ALN64I"@@d_regcomp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3399,		T_INV,0,ALN64I"@@d_vendorlib@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3401,		T_INV,0,ALN64I"@@mydomain@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3412,		T_INV,0,ALN64I"@@git_describe@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3435,		T_INV,0,ALN64I"@@d_xenix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3440,			T_INV,0,ALN64I"@@d_fork@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3443,		T_INV,0,ALN64I"@@madlyobj@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3444,		T_INV,0,ALN64I"@@loclibpth@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3446,		T_INV,0,ALN64I"@@i_varhdr@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3450,		T_INV,0,ALN64I"@@d_fpgetround@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3456,		T_INV,0,ALN64I"@@d_grpasswd@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3464,		T_INV,0,ALN64I"@@d_voidsig@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3466,		T_INV,0,ALN64I"@@sig_count@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3473,		T_INV,0,ALN64I"@@versiononly@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3485,		T_INV,0,ALN64I"@@d_getpwent@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3488,	T_INV,0,ALN64I"@@d_sin6_scope_id@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3494,		T_INV,0,ALN64I"@@i_sysuio@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3501,	T_INV,0,ALN64I"@@d_getnetbyaddr_r@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3504,		T_INV,0,ALN64I"@@i_sysparam@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3507,	T_INV,0,ALN64I"@@d_pthread_attr_setscope@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3514,		T_INV,0,ALN64I"@@d_ptrdiff_t@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3517,		T_INV,0,ALN64I"@@d_getnbyaddr@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3520,		T_INV,0,ALN64I"@@d_fgetpos@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3523,	T_INV,0,ALN64I"@@getprotoent_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3529,		T_INV,0,ALN64I"@@d_recvmsg@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3538,		T_INV,0,ALN64I"@@d_gettimeod@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3540,	T_INV,0,ALN64I"@@d_shmatprototype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3545,		T_INV,0,ALN64I"@@installprivlib@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3552,	T_INV,0,ALN64I"@@db_version_minor@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3555,		T_INV,0,ALN64I"@@d_socket@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3558,		T_INV,0,ALN64I"@@i_sysutsname@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3560,		T_INV,0,ALN64I"@@d_memcpy@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3561,	T_INV,0,ALN64I"@@setpwent_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3562,		T_INV,0,ALN64I"@@html3dir@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3564,	T_INV,0,ALN64I"@@endpwent_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3566,		T_INV,0,ALN64I"@@d_sched_yield@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3567,		T_INV,0,ALN64I"@@html1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3576,	T_INV,0,ALN64I"@@installprefixexp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3579,		T_INV,0,ALN64I"@@uvoformat@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3582,		T_INV,0,ALN64I"@@d_localtime_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3589,			T_INV,0,ALN64I"@@binexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3600,		T_INV,0,ALN64I"@@nvfformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3607,	T_INV,0,ALN64I"@@d_localtime_r_needs_tzset@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3619,		T_INV,0,ALN64I"@@d_getespwnam@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3632,	T_INV,0,ALN64I"@@gethostent_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3636,		T_INV,0,ALN64I"@@mmaptype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3638,		T_INV,0,ALN64I"@@privlibexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3644,		T_INV,0,ALN64I"@@randseedtype@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3647,			T_INV,0,ALN64I"@@uvtype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3651,		T_INV,0,ALN64I"@@xlibpth@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3658,		T_INV,0,ALN64I"@@d_setpgrp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3662,		T_INV,0,ALN64I"@@subversion@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3666,		T_INV,0,ALN64I"@@i_systime@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3668,		T_INV,0,ALN64I"@@i_systimes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3676,		T_INV,0,ALN64I"@@api_revision@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3678,		T_INV,0,ALN64I"@@freetype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3685,		T_INV,0,ALN64I"@@uselongdouble@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3688,		T_INV,0,ALN64I"@@d_getsbyname@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3689,		T_INV,0,ALN64I"@@d_getnbyname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3695,		T_INV,0,ALN64I"@@libsfound@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3697,	T_INV,0,ALN64I"@@installsitearch@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3698,		T_INV,0,ALN64I"@@d_setpgrp2@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3699,		T_INV,0,ALN64I"@@vendorscript@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3719,	T_INV,0,ALN64I"@@d_getprotoent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3728,		T_INV,0,ALN64I"@@i_systypes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3734,		T_INV,0,ALN64I"@@targetmkdir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3741,		T_INV,0,ALN64I"@@ctime_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3744,		T_INV,0,ALN64I"@@selecttype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3775,		T_INV,0,ALN64I"@@i_langinfo@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3778,		T_INV,0,ALN64I"@@d_mbtowc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3786,		T_INV,0,ALN64I"@@nvEUformat@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3788,		T_INV,0,ALN64I"@@nvGUformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3793,		T_INV,0,ALN64I"@@nvFUformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3799,		T_INV,0,ALN64I"@@d_getprpwnam@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3800,		T_INV,0,ALN64I"@@i_syswait@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3802,	T_INV,0,ALN64I"@@getgrent_r_proto@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3804,		T_INV,0,ALN64I"@@hostgenerate@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3806,		T_INV,0,ALN64I"@@d_fstatvfs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3811,			T_INV,0,ALN64I"@@gmake@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3813,		T_INV,0,ALN64I"@@d_writev@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3814,		T_INV,0,ALN64I"@@vendorlib_stem@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3821,		T_INV,0,ALN64I"@@yaccflags@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3823,		T_INV,0,ALN64I"@@d_safemcpy@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3836,		T_INV,0,ALN64I"@@regexec_cflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3837,	T_INV,0,ALN64I"@@installvendorbin@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3846,	T_INV,0,ALN64I"@@getnetbyaddr_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3847,		T_INV,0,ALN64I"@@d_getlogin@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3848,		T_INV,0,ALN64I"@@d_strctcpy@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3850,		T_INV,0,ALN64I"@@cpp_stuff@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3852,	T_INV,0,ALN64I"@@longdblinfbytes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3871,		T_INV,0,ALN64I"@@d_getpbyname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3881,		T_INV,0,ALN64I"@@i_sysvfs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3885,		T_INV,0,ALN64I"@@lib_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3893,	T_INV,0,ALN64I"@@installvendorlib@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3897,		T_INV,0,ALN64I"@@ieeefp_h@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3908,		T_INV,0,ALN64I"@@nvgformat@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3910,		T_INV,0,ALN64I"@@d_getpwent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3915,		T_INV,0,ALN64I"@@uvuformat@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3916,		T_INV,0,ALN64I"@@d_lockf@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3918,		T_INV,0,ALN64I"@@fpostype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3929,			T_INV,0,ALN64I"@@nvsize@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3931,			T_INV,0,ALN64I"@@ivsize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3956,		T_INV,0,ALN64I"@@d_safebcpy@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3973,		T_INV,0,ALN64I"@@d_getservent_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3985,		T_INV,0,ALN64I"@@d_setlinebuf@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3986,	T_INV,0,ALN64I"@@git_commit_date@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str3994,		T_INV,0,ALN64I"@@d_fchdir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4001,		T_INV,0,ALN64I"@@procselfexe@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4002,	T_INV,0,ALN64I"@@d_static_inline@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4018,	T_INV,0,ALN64I"@@getnetbyname_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4024,		T_INV,0,ALN64I"@@d_lchown@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4047,		T_INV,0,ALN64I"@@d_pwpasswd@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4059,		T_INV,0,ALN64I"@@malloctype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4061,		T_INV,0,ALN64I"@@sched_yield@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5171,	T_INV,0,ALN64I"@@d_stdio_ptr_lval@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4088,	T_INV,0,ALN64I"@@d_statfs_f_flags@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4091,			T_INV,0,ALN64I"@@awk@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5184,		T_INV,0,ALN64I"@@d_vendorarch@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4095,		T_INV,0,ALN64I"@@d_getspnam@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5186,	T_INV,0,ALN64I"@@d_stdio_ptr_lval_sets_cnt@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5187,		T_INV,0,ALN64I"@@groupstype@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5191,	T_INV,0,ALN64I"@@d_stdio_ptr_lval_nochange_cnt@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4097,		T_INV,0,ALN64I"@@i_sysfile@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5197,		T_INV,0,ALN64I"@@exe_ext@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4130,		T_INV,0,ALN64I"@@d_sockatmark@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5206,		T_INV,0,ALN64I"@@lseeksize@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5218,	T_INV,0,ALN64I"@@ccflags_uselargefiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5227,		T_INV,0,ALN64I"@@d_wcsxfrm@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5229,	T_INV,0,ALN64I"@@d_gdbm_ndbm_h_uses_prototypes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4134,		T_INV,0,ALN64I"@@d_gethostent_r@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5242,	T_INV,0,ALN64I"@@d_void_closedir@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4147,		T_INV,0,ALN64I"@@direntrytype@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5252,		T_INV,0,ALN64I"@@i_execinfo@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4150,		T_INV,0,ALN64I"@@dynamic_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5278,		T_INV,0,ALN64I"@@d_killpg@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4154,		T_INV,0,ALN64I"@@fflushall@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4166,		T_INV,0,ALN64I"@@d_sockaddr_in6@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4168,			T_INV,0,ALN64I"@@ksh@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5284,	T_INV,0,ALN64I"@@ldflags_uselargefiles@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5287,		T_INV,0,ALN64I"@@usequadmath@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5303,		T_INV,0,ALN64I"@@d_mkstemp@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5305,		T_INV,0,ALN64I"@@d_mkstemps@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5307,		T_INV,0,ALN64I"@@d_mkdtemp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5318,	T_INV,0,ALN64I"@@d_getservbyport_r@@"},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5319,		T_INV,0,ALN64I"@@hash_func@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5333,		T_INV,0,ALN64I"@@gccosandvers@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5354,	T_INV,0,ALN64I"@@d_sockaddr_sa_len@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5386,		T_INV,0,ALN64I"@@socksizetype@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5389,	T_INV,0,ALN64I"@@getlogin_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4174,		T_INV,0,ALN64I"@@usemorebits@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5407,		T_INV,0,ALN64I"@@d_sbrkproto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4192,	T_INV,0,ALN64I"@@d_vms_case_sensitive_symbols@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4195,		T_INV,0,ALN64I"@@uselargefiles@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5409,		T_INV,0,ALN64I"@@d_qgcvt@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4197,		T_INV,0,ALN64I"@@extern_C@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4199,		T_INV,0,ALN64I"@@d_msghdr_s@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4206,		T_INV,0,ALN64I"@@uvXUformat@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4208,	T_INV,0,ALN64I"@@d_siginfo_si_value@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4212,		T_INV,0,ALN64I"@@api_version@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4218,		T_INV,0,ALN64I"@@shmattype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4222,		T_INV,0,ALN64I"@@db_prefixtype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4224,	T_INV,0,ALN64I"@@getspnam_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4238,	T_INV,0,ALN64I"@@localtime_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4251,		T_INV,0,ALN64I"@@o_nonblock@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4253,		T_INV,0,ALN64I"@@random_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4258,		T_INV,0,ALN64I"@@config_args@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4260,		T_INV,0,ALN64I"@@config_arg5@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4262,		T_INV,0,ALN64I"@@config_arg6@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4264,		T_INV,0,ALN64I"@@config_arg0@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4267,		T_INV,0,ALN64I"@@i_xlocale@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4272,		T_INV,0,ALN64I"@@d_getlogin_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4277,	T_INV,0,ALN64I"@@longdblnanbytes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4282,		T_INV,0,ALN64I"@@config_arg3@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4283,		T_INV,0,ALN64I"@@config_arg7@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4285,		T_INV,0,ALN64I"@@d_gnulibc@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4286,		T_INV,0,ALN64I"@@config_arg32@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4287,		T_INV,0,ALN64I"@@config_arg1@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4288,		T_INV,0,ALN64I"@@config_arg33@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4289,		T_INV,0,ALN64I"@@config_arg4@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4291,		T_INV,0,ALN64I"@@config_arg12@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4293,		T_INV,0,ALN64I"@@config_arg13@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4296,		T_INV,0,ALN64I"@@config_arg2@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4298,		T_INV,0,ALN64I"@@config_arg39@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4300,		T_INV,0,ALN64I"@@config_arg22@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4302,		T_INV,0,ALN64I"@@config_arg23@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4303,		T_INV,0,ALN64I"@@config_arg19@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4304,		T_INV,0,ALN64I"@@d_remquo@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4306,		T_INV,0,ALN64I"@@lkflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4307,		T_INV,0,ALN64I"@@config_arg8@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4308,		T_INV,0,ALN64I"@@config_arg30@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4309,		T_INV,0,ALN64I"@@config_arg34@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4310,		T_INV,0,ALN64I"@@config_arg9@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4312,		T_INV,0,ALN64I"@@config_arg29@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4313,		T_INV,0,ALN64I"@@config_arg10@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4314,		T_INV,0,ALN64I"@@config_arg14@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4315,		T_INV,0,ALN64I"@@config_arg31@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4316,	T_INV,0,ALN64I"@@git_uncommitted_changes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4320,		T_INV,0,ALN64I"@@config_arg11@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4321,		T_INV,0,ALN64I"@@config_arg38@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4322,		T_INV,0,ALN64I"@@config_arg20@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4323,		T_INV,0,ALN64I"@@config_arg24@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4325,		T_INV,0,ALN64I"@@config_arg37@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4326,		T_INV,0,ALN64I"@@config_arg18@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4327,	T_INV,0,ALN64I"@@d_getprotobynumber_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4328,		T_INV,0,ALN64I"@@git_branch@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4329,		T_INV,0,ALN64I"@@config_arg21@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4330,		T_INV,0,ALN64I"@@config_arg17@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4333,		T_INV,0,ALN64I"@@config_arg35@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4334,	T_INV,0,ALN64I"@@d_sockatmarkproto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4335,		T_INV,0,ALN64I"@@config_arg28@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4336,		T_INV,0,ALN64I"@@config_arg36@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4338,		T_INV,0,ALN64I"@@config_arg15@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4339,		T_INV,0,ALN64I"@@config_arg27@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4341,		T_INV,0,ALN64I"@@config_arg16@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4347,		T_INV,0,ALN64I"@@config_arg25@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4348,			T_INV,0,ALN64I"@@uvsize@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4350,		T_INV,0,ALN64I"@@config_arg26@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4353,		T_INV,0,ALN64I"@@i_quadmath@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5418,	T_INV,0,ALN64I"@@usemultiplicity@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5426,		T_INV,0,ALN64I"@@d_getservent_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4362,	T_INV,0,ALN64I"@@installvendorarch@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5457,		T_INV,0,ALN64I"@@usevfork@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4366,		T_INV,0,ALN64I"@@ccwarnflags@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4367,		T_INV,0,ALN64I"@@ccversion@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5467,		T_INV,0,ALN64I"@@h_sysfile@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4377,	T_INV,0,ALN64I"@@installsitescript@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5474,		T_INV,0,ALN64I"@@d_charvspr@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4378,	T_INV,0,ALN64I"@@perl_patchlevel@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4390,		T_INV,0,ALN64I"@@d_nextafter@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5485,		T_INV,0,ALN64I"@@siteprefix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4392,		T_INV,0,ALN64I"@@config_argc@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5491,		T_INV,0,ALN64I"@@d_usleepproto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5498,		T_INV,0,ALN64I"@@d_pwquota@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4393,	T_INV,0,ALN64I"@@getpwent_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5507,		T_INV,0,ALN64I"@@siteprefixexp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4402,		T_INV,0,ALN64I"@@d_mkfifo@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4409,	T_INV,0,ALN64I"@@installvendorhtml3dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4414,	T_INV,0,ALN64I"@@installvendorhtml1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4421,		T_INV,0,ALN64I"@@cryptlib@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5517,	T_INV,0,ALN64I"@@gccansipedantic@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5524,		T_INV,0,ALN64I"@@crypt_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5531,	T_INV,0,ALN64I"@@bootstrap_charset@@"},
-      {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5533,		T_INV,0,ALN64I"@@d_pwchange@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4442,		T_INV,0,ALN64I"@@alignbytes@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5539,	T_INV,0,ALN64I"@@getpwnam_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4448,		T_INV,0,ALN64I"@@d_voidtty@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4462,		T_INV,0,ALN64I"@@extensions@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4463,	T_INV,0,ALN64I"@@sitehtml3direxp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4466,		T_INV,0,ALN64I"@@sig_num_init@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4470,	T_INV,0,ALN64I"@@sitehtml1direxp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4473,		T_INV,0,ALN64I"@@tmpnam_r_proto@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4476,	T_INV,0,ALN64I"@@d_printf_format_null@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4490,		T_INV,0,ALN64I"@@d_getpgrp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4491,		T_INV,0,ALN64I"@@d_fchown@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5550,		T_INV,0,ALN64I"@@vendorprefix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4502,		T_INV,0,ALN64I"@@d_bsdsetpgrp@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5593,		T_INV,0,ALN64I"@@i_sysfilio@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4509,		T_INV,0,ALN64I"@@d_sigsetjmp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5600,		T_INV,0,ALN64I"@@obj_ext@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4520,		T_INV,0,ALN64I"@@d_getspnam_r@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5616,	T_INV,0,ALN64I"@@d_attribute_deprecated@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4521,		T_INV,0,ALN64I"@@sitearchexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4530,		T_INV,0,ALN64I"@@d_getpgrp2@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4531,		T_INV,0,ALN64I"@@voidflags@@"},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5692,		T_INV,0,ALN64I"@@d_ipv6_mreq@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4535,		T_INV,0,ALN64I"@@mallocobj@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4537,		T_INV,0,ALN64I"@@package@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4543,		T_INV,0,ALN64I"@@vendorarch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4547,		T_INV,0,ALN64I"@@d_ldexpl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4552,		T_INV,0,ALN64I"@@vendorarchexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4556,		T_INV,0,ALN64I"@@spackage@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4576,		T_INV,0,ALN64I"@@use64bitall@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4590,		T_INV,0,ALN64I"@@gccosandvers@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4591,		T_INV,0,ALN64I"@@db_hashtype@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5710,	T_INV,0,ALN64I"@@vendorhtml3direxp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4609,		T_INV,0,ALN64I"@@ssizetype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5715,		T_INV,0,ALN64I"@@d_getnetprotos@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4616,		T_INV,0,ALN64I"@@d_madvise@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5729,		T_INV,0,ALN64I"@@quadtype@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4635,		T_INV,0,ALN64I"@@d_wcsxfrm@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4641,		T_INV,0,ALN64I"@@d_usleepproto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5744,	T_INV,0,ALN64I"@@vendorhtml1direxp@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5752,		T_INV,0,ALN64I"@@doublenanbytes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4656,		T_INV,0,ALN64I"@@st_ino_sign@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4689,		T_INV,0,ALN64I"@@vendorbinexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4693,	T_INV,0,ALN64I"@@libs_nolargefiles@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4698,	T_INV,0,ALN64I"@@d_builtin_prefetch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4753,		T_INV,0,ALN64I"@@vendorlibexp@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4756,		T_INV,0,ALN64I"@@perl_revision@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4767,	T_INV,0,ALN64I"@@db_version_patch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4779,		T_INV,0,ALN64I"@@d__fwalk@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4788,		T_INV,0,ALN64I"@@ldlibpthname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4820,		T_INV,0,ALN64I"@@d_getnetprotos@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4830,	T_INV,0,ALN64I"@@d_getservbyport_r@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5781,	T_INV,0,ALN64I"@@d_nv_preserves_uv@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4850,		T_INV,0,ALN64I"@@d_getpagsz@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5823,	T_INV,0,ALN64I"@@BuiltWithPatchPerl@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4853,		T_INV,0,ALN64I"@@crypt_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5864,	T_INV,0,ALN64I"@@d_attribute_malloc@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4858,	T_INV,0,ALN64I"@@vendorman3direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5912,		T_INV,0,ALN64I"@@i_systimek@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5915,	T_INV,0,ALN64I"@@d_attribute_unused@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5919,	T_INV,0,ALN64I"@@d_attribute_pure@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4863,	T_INV,0,ALN64I"@@vendorman1direxp@@"},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5921,		T_INV,0,ALN64I"@@d_msg_peek@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4865,		T_INV,0,ALN64I"@@shsharp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4867,		T_INV,0,ALN64I"@@d_getgrgid_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4876,		T_INV,0,ALN64I"@@patchlevel@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5937,	T_INV,0,ALN64I"@@d_attribute_format@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5944,		T_INV,0,ALN64I"@@git_unpushed@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5957,	T_INV,0,ALN64I"@@getgrgid_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4888,		T_INV,0,ALN64I"@@d_gethbyaddr@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5967,	T_INV,0,ALN64I"@@d_attribute_warn_unused_result@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4898,	T_INV,0,ALN64I"@@getgrnam_r_proto@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4899,		T_INV,0,ALN64I"@@d_socks5_init@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5972,		T_INV,0,ALN64I"@@nonxs_ext@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4904,		T_INV,0,ALN64I"@@canned_gperf@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5976,	T_INV,0,ALN64I"@@d_builtin_arith_overflow@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4923,	T_INV,0,ALN64I"@@d_fcntl_can_lock@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4928,		T_INV,0,ALN64I"@@d_charvspr@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6020,		T_INV,0,ALN64I"@@d_getpwuid_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4954,		T_INV,0,ALN64I"@@perl_version@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6077,	T_INV,0,ALN64I"@@getprotobynumber_r_proto@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4973,		T_INV,0,ALN64I"@@useposix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4977,		T_INV,0,ALN64I"@@d_flexfnam@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6106,		T_INV,0,ALN64I"@@uvxformat@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4988,	T_INV,0,ALN64I"@@ldflags_uselargefiles@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6118,		T_INV,0,ALN64I"@@longdblkind@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str4997,	T_INV,0,ALN64I"@@d_gethostbyaddr_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5006,		T_INV,0,ALN64I"@@d_getpwnam_r@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5007,		T_INV,0,ALN64I"@@d_attribut@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6126,	T_INV,0,ALN64I"@@d_attribute_noreturn@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5024,		T_INV,0,ALN64I"@@i_gdbm_ndbm@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5034,		T_INV,0,ALN64I"@@d_scm_rights@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5035,		T_INV,0,ALN64I"@@d_frexpl@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5041,	T_INV,0,ALN64I"@@useversionedarchname@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5058,	T_INV,0,ALN64I"@@usesitecustomize@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5060,		T_INV,0,ALN64I"@@d_gethbyname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5069,		T_INV,0,ALN64I"@@sharpbang@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5070,		T_INV,0,ALN64I"@@sizetype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5076,	T_INV,0,ALN64I"@@d_builtin_choose_expr@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5093,		T_INV,0,ALN64I"@@groupstype@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5095,		T_INV,0,ALN64I"@@gmtime_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6185,	T_INV,0,ALN64I"@@d_attribute_nonnull@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5127,		T_INV,0,ALN64I"@@cppccsymbols@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5148,		T_INV,0,ALN64I"@@exe_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5162,		T_INV,0,ALN64I"@@d_pwquota@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5180,		T_INV,0,ALN64I"@@doublenanbytes@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5182,	T_INV,0,ALN64I"@@inc_version_list@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5190,	T_INV,0,ALN64I"@@BuiltWithPatchPerl@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5192,	T_INV,0,ALN64I"@@usemultiplicity@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5193,	T_INV,0,ALN64I"@@inc_version_list_init@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5195,	T_INV,0,ALN64I"@@ccflags_uselargefiles@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6228,		T_INV,0,ALN64I"@@d_getsbyport@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6254,	T_INV,0,ALN64I"@@d_libm_lib_version@@"},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6258,	T_INV,0,ALN64I"@@usensgetexecutablepath@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6277,		T_INV,0,ALN64I"@@d_nexttoward@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6280,		T_INV,0,ALN64I"@@otherlibdirs@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6320,	T_INV,0,ALN64I"@@d_nv_zero_is_allbits_zero@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6369,		T_INV,0,ALN64I"@@d_sockpair@@"},
-      {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6372,	T_INV,0,ALN64I"@@gnulibc_version@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6506,	T_INV,0,ALN64I"@@d_pthread_atfork@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5220,	T_INV,0,ALN64I"@@installsitehtml3dir@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6520,		T_INV,0,ALN64I"@@useshrplib@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5225,	T_INV,0,ALN64I"@@installsitehtml1dir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6526,	T_INV,0,ALN64I"@@usevendorprefix@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5243,		T_INV,0,ALN64I"@@vendorprefix@@"},
+      {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6532,		T_INV,0,ALN64I"@@html3direxp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5246,	T_INV,0,ALN64I"@@libdb_needs_pthread@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5295,		T_INV,0,ALN64I"@@hash_func@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5298,		T_INV,0,ALN64I"@@malloc_cflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5311,	T_INV,0,ALN64I"@@usekernprocpathname@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5330,	T_INV,0,ALN64I"@@d_malloc_good_size@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5334,		T_INV,0,ALN64I"@@d_bsdgetpgrp@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5335,	T_INV,0,ALN64I"@@installhtmlhelpdir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5345,		T_INV,0,ALN64I"@@use64bitint@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5346,		T_INV,0,ALN64I"@@i_execinfo@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5368,	T_INV,0,ALN64I"@@ignore_versioned_solibs@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5371,		T_INV,0,ALN64I"@@longlongsize@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6566,		T_INV,0,ALN64I"@@html1direxp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5387,		T_INV,0,ALN64I"@@d_pwchange@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5402,	T_INV,0,ALN64I"@@d_stdio_ptr_lval@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5403,		T_INV,0,ALN64I"@@quadkind@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5414,	T_INV,0,ALN64I"@@d_stdio_ptr_lval_sets_cnt@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6580,		T_INV,0,ALN64I"@@d_pwexpire@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5419,	T_INV,0,ALN64I"@@d_stdio_ptr_lval_nochange_cnt@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5430,		T_INV,0,ALN64I"@@d_qgcvt@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5437,		T_INV,0,ALN64I"@@usecbacktrace@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5465,	T_INV,0,ALN64I"@@db_version_major@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5466,		T_INV,0,ALN64I"@@h_sysfile@@"},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6664,		T_INV,0,ALN64I"@@i_sysstatvfs@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5469,	T_INV,0,ALN64I"@@d_perl_otherlibdirs@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5480,		T_INV,0,ALN64I"@@d_getsbyport@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6696,	T_INV,0,ALN64I"@@libswanted_nolargefiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5485,		T_INV,0,ALN64I"@@archobjs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5489,	T_INV,0,ALN64I"@@getpwnam_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5496,		T_INV,0,ALN64I"@@make_set_make@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5502,		T_INV,0,ALN64I"@@usequadmath@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6736,		T_INV,0,ALN64I"@@d_msg_proxy@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5515,		T_INV,0,ALN64I"@@lseektype@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6799,		T_INV,0,ALN64I"@@config_heavy@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5551,		T_INV,0,ALN64I"@@siteprefix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6809,	T_INV,0,ALN64I"@@getpwuid_r_proto@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5560,		T_INV,0,ALN64I"@@siteprefixexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5573,		T_INV,0,ALN64I"@@i_sysfilio@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5586,	T_INV,0,ALN64I"@@getservbyname_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5592,		T_INV,0,ALN64I"@@uquadtype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5604,	T_INV,0,ALN64I"@@vendorhtml3direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5609,	T_INV,0,ALN64I"@@vendorhtml1direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5627,		T_INV,0,ALN64I"@@dtraceobject@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5629,		T_INV,0,ALN64I"@@d_backtrace@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5633,		T_INV,0,ALN64I"@@quadtype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5651,	T_INV,0,ALN64I"@@d_gdbmndbm_h_uses_prototypes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5660,	T_INV,0,ALN64I"@@d_void_closedir@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5675,	T_INV,0,ALN64I"@@d_nv_preserves_uv@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6820,	T_INV,0,ALN64I"@@d_ndbm_h_uses_prototypes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5686,		T_INV,0,ALN64I"@@firstmakefile@@"},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5687,		T_INV,0,ALN64I"@@d_mkstemp@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5689,		T_INV,0,ALN64I"@@d_mkstemps@@"},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5691,		T_INV,0,ALN64I"@@d_mkdtemp@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5723,		T_INV,0,ALN64I"@@d_ldbl_dig@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5730,	T_INV,0,ALN64I"@@gnulibc_version@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5746,	T_INV,0,ALN64I"@@getlogin_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5759,		T_INV,0,ALN64I"@@nonxs_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5763,		T_INV,0,ALN64I"@@st_ino_size@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5789,		T_INV,0,ALN64I"@@toke_cflags@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5808,		T_INV,0,ALN64I"@@usevfork@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5812,		T_INV,0,ALN64I"@@d_killpg@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5823,		T_INV,0,ALN64I"@@obj_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5850,		T_INV,0,ALN64I"@@uvxformat@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5865,		T_INV,0,ALN64I"@@clocktype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5878,		T_INV,0,ALN64I"@@shortsize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5885,		T_INV,0,ALN64I"@@d_pwexpire@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5950,	T_INV,0,ALN64I"@@d_builtin_arith_overflow@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str5962,		T_INV,0,ALN64I"@@git_unpushed@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6004,	T_INV,0,ALN64I"@@gccansipedantic@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6036,		T_INV,0,ALN64I"@@longdblsize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6041,	T_INV,0,ALN64I"@@libswanted_nolargefiles@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6059,	T_INV,0,ALN64I"@@getservbyport_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6070,		T_INV,0,ALN64I"@@socksizetype@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6134,		T_INV,0,ALN64I"@@d_nexttoward@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6144,	T_INV,0,ALN64I"@@d_sockaddr_sa_len@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6161,		T_INV,0,ALN64I"@@d_getpwuid_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6171,	T_INV,0,ALN64I"@@gethostbyname_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6187,		T_INV,0,ALN64I"@@d_ipv6_mreq@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6199,		T_INV,0,ALN64I"@@d_vendorarch@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6222,		T_INV,0,ALN64I"@@d_sbrkproto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6242,	T_INV,0,ALN64I"@@vendorscriptexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6274,	T_INV,0,ALN64I"@@bootstrap_charset@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6877,	T_INV,0,ALN64I"@@vendorscriptexp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6304,	T_INV,0,ALN64I"@@getprotobynumber_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6888,	T_INV,0,ALN64I"@@d_gethostbyname_r@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6345,	T_INV,0,ALN64I"@@libswanted_uselargefiles@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6989,	T_INV,0,ALN64I"@@libswanted_uselargefiles@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6346,	T_INV,0,ALN64I"@@d_attribute_format@@"},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7114,	T_INV,0,ALN64I"@@d_ipv6_mreq_source@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6347,	T_INV,0,ALN64I"@@usensgetexecutablepath@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6368,	T_INV,0,ALN64I"@@d_pthread_atfork@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6373,		T_INV,0,ALN64I"@@d_msg_peek@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6405,	T_INV,0,ALN64I"@@d_attribute_deprecated@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6419,	T_INV,0,ALN64I"@@d_attribute_malloc@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6424,		T_INV,0,ALN64I"@@i_sysstatvfs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6448,	T_INV,0,ALN64I"@@usevendorprefix@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6458,		T_INV,0,ALN64I"@@i_systimek@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6465,	T_INV,0,ALN64I"@@getgrgid_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6483,	T_INV,0,ALN64I"@@d_attribute_unused@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7130,	T_INV,0,ALN64I"@@api_versionstring@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6499,	T_INV,0,ALN64I"@@d_attribute_pure@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6505,	T_INV,0,ALN64I"@@d_gdbm_ndbm_h_uses_prototypes@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6515,		T_INV,0,ALN64I"@@otherlibdirs@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6546,	T_INV,0,ALN64I"@@d_attribute_warn_unused_result@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6591,	T_INV,0,ALN64I"@@d_attribute_noreturn@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6621,	T_INV,0,ALN64I"@@d_attribute_nonnull@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6630,		T_INV,0,ALN64I"@@html3direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6635,		T_INV,0,ALN64I"@@html1direxp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6639,	T_INV,0,ALN64I"@@d_modfl_pow32_bug@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6644,	T_INV,0,ALN64I"@@getpwuid_r_proto@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7282,	T_INV,0,ALN64I"@@perl_subversion@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6652,	T_INV,0,ALN64I"@@perl_subversion@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7391,	T_INV,0,ALN64I"@@version_patchlevel_string@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6679,		T_INV,0,ALN64I"@@d_msg_proxy@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7453,	T_INV,0,ALN64I"@@d_libname_unique@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6823,	T_INV,0,ALN64I"@@gethostbyaddr_r_proto@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6891,		T_INV,0,ALN64I"@@longdblkind@@"},
+      {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6895,		T_INV,0,ALN64I"@@useshrplib@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str6910,	T_INV,0,ALN64I"@@version_patchlevel_string@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6785,7 +6730,34 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7538,	T_INV,0,ALN64I"@@d_modfl_pow32_bug@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7004,	T_INV,0,ALN64I"@@d_getservbyname_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7054,		T_INV,0,ALN64I"@@d_sockpair@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7057,	T_INV,0,ALN64I"@@api_versionstring@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7165,	T_INV,0,ALN64I"@@d_gethostbyname_r@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6794,7 +6766,24 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7599,	T_INV,0,ALN64I"@@d_getservbyname_r@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7244,		T_INV,0,ALN64I"@@lseeksize@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7253,	T_INV,0,ALN64I"@@d_libm_lib_version@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7314,		T_INV,0,ALN64I"@@config_heavy@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6837,17 +6826,74 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7969,		T_INV,0,ALN64I"@@doubleinfbytes@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7729,		T_INV,0,ALN64I"@@doubleinfbytes@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8038,	T_INV,0,ALN64I"@@vendorprefixexp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7783,	T_INV,0,ALN64I"@@d_libname_unique@@"},
+      {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7786,	T_INV,0,ALN64I"@@vendorprefixexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7851,	T_INV,0,ALN64I"@@d_nv_zero_is_allbits_zero@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str7898,	T_INV,0,ALN64I"@@d_ipv6_mreq_source@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8040,		T_INV,0,ALN64I"@@prefixexp@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8164,		T_INV,0,ALN64I"@@dl_so_eq_ext@@"},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6859,7 +6905,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8122,		T_INV,0,ALN64I"@@prefixexp@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8284,	T_INV,0,ALN64I"@@d_ndbm_h_uses_prototypes@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6904,8 +6950,34 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8519,		T_INV,0,ALN64I"@@dl_so_eq_ext@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str8907,	T_INV,0,ALN64I"@@nv_overflows_integers_at@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -6975,54 +7047,9 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str9553,	T_INV,0,ALN64I"@@nv_preserves_uv_bits@@"},
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str9532,	T_INV,0,ALN64I"@@known_extensions@@"},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
@@ -7030,77 +7057,12 @@ Config_lookup (register const char *str, register unsigned int len)
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
       {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
+      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
 
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str10035,	T_INV,0,ALN64I"@@known_extensions@@"},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-      {XSCNO}, {XSCNO}, {XSCNO}, {XSCNO},
-
-      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str10184,	T_INV,0,ALN64I"@@nv_overflows_integers_at@@"}
+      {(U16)(long)&((struct stringpool_t *)0)->stringpool_str9602,	T_INV,0,ALN64I"@@nv_preserves_uv_bits@@"}
     };
 
-#line 7103 "Config.xs"
+#line 7065 "Config.xs"
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
       register int key = Config_hash (str, len);
@@ -7167,7 +7129,8 @@ PREINIT:
 PPCODE:
   SV * const sv = MY_CXT.defineSV;
   MY_CXT.defineSV = NULL;
-  SvREFCNT_dec_NN(sv);
+  if (sv) /* already NULL in global destruction */
+    SvREFCNT_dec_NN(sv);
   return; /* skip implicit PUTBACK, returning @_ to caller, more efficient*/
 
 #endif


### PR DESCRIPTION
protect sv in END during global destruction, esp. with B::C
fixes for no . in @INC (cperl or -Dfortify_inc)

should I upload it?
